### PR TITLE
fix: support for custom key map

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -571,6 +571,7 @@ func getFakedValue(a interface{}, opts *options.Options) (reflect.Value, error) 
 			if err != nil {
 				return reflect.Value{}, err
 			}
+			key = key.Convert(t.Key())
 			val = val.Convert(v.Type().Elem())
 			v.SetMapIndex(key, val)
 		}

--- a/faker_test.go
+++ b/faker_test.go
@@ -75,7 +75,7 @@ func TestPLen(t *testing.T) {
 }
 
 type SomeInt32 int32
-
+type SomeString string
 type TArray [16]byte
 
 type SomeStruct struct {
@@ -125,6 +125,8 @@ type SomeStruct struct {
 
 	MapStringString        map[string]string
 	MapStringStruct        map[string]AStruct
+	MapCustomStringStruct  map[SomeString]AStruct
+	MapCustomStringString  map[SomeString]string
 	MapStringStructPointer map[string]*AStruct
 
 	SomeInt32s []SomeInt32


### PR DESCRIPTION
With a custom key map, we get a panic.

```
package main

import "github.com/go-faker/faker/v4"

func main()  {
	type CustomString string
	type CustomStruct struct {
		Map map[CustomString]string
	}

	faker.FakeData(&CustomStruct{})
}
```
This PR will fix this issue by converting the reflected map key.