### PR TITLE
fix: slice-len for slices with pointers

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -880,6 +880,19 @@ func userDefinedArray(v reflect.Value, tag string, opt options.Options) error {
 	tag = findSliceLenReg.ReplaceAllString(tag, "")
 	array := reflect.MakeSlice(v.Type(), sliceLen, sliceLen)
 	for i := 0; i < array.Len(); i++ {
+		k := v.Type().Elem().Kind()
+		if k == reflect.Pointer || k == reflect.Struct {
+			res, err := getFakedValue(array.Index(i).Interface(), &opt)
+			if err != nil {
+				return err
+			}
+			if res.Kind() == reflect.Invalid {
+				return fmt.Errorf("got invalid reflect value")
+			}
+			array.Index(i).Set(res)
+			continue
+		}
+
 		if tag == "" {
 			res, err := getValueWithNoTag(v.Type().Elem(), opt)
 			if err != nil {

--- a/faker_test.go
+++ b/faker_test.go
@@ -786,6 +786,40 @@ func TestSliceLen(t *testing.T) {
 	}
 }
 
+func TestSliceOfStructPointersLen(t *testing.T) {
+	type Child struct {
+		ID    int
+		Value string
+	}
+	type Parent struct {
+		Children []*Child `faker:"slice_len=3"`
+	}
+	var p Parent
+	if err := FakeData(&p); err != nil {
+		t.Fatalf("failed to generate fake data: %s", err.Error())
+	}
+	if len(p.Children) != 3 {
+		t.Errorf("wrong slice length based on slice_len tag, got %d, wanted 3", len(p.Children))
+	}
+}
+
+func TestSliceOfStructsLen(t *testing.T) {
+	type Child struct {
+		ID    int
+		Value string
+	}
+	type Parent struct {
+		Children []Child `faker:"slice_len=5"`
+	}
+	var p Parent
+	if err := FakeData(&p); err != nil {
+		t.Fatalf("failed to generate fake data: %s", err.Error())
+	}
+	if len(p.Children) != 5 {
+		t.Errorf("wrong slice length based on slice_len tag, got %d, wanted 5", len(p.Children))
+	}
+}
+
 func TestWrongSliceLen(t *testing.T) {
 	type SomeStruct struct {
 		String []string `faker:"slice_len=bla"`


### PR DESCRIPTION
Encountered issue #19, where Unknown Type errors occurred when attempting to fake data for slices with pointers to structs with the slice_len tag.  Despite attempts by the repository owner to contact the original author, there has been no response, prompting me to reimplement the fix.