### PR TITLE
support custom domain for generate fake email

### DIFF
--- a/internet.go
+++ b/internet.go
@@ -68,10 +68,19 @@ func (internet Internet) email() (string, error) {
 	if emailName, err = randomString(7, internet.fakerOption); err != nil {
 		return "", err
 	}
-	if emailDomain, err = randomString(7, internet.fakerOption); err != nil {
-		return "", err
+
+	if internet.fakerOption.CustomDomain != nil {
+		emailDomain = *internet.fakerOption.CustomDomain
+	} else {
+		randDomain, err := randomString(7, internet.fakerOption)
+		if err != nil {
+			return "", err
+		}
+
+		emailDomain = randDomain + "." + randomElementFromSliceString(tld)
 	}
-	return (emailName + "@" + emailDomain + "." + randomElementFromSliceString(tld)), nil
+
+	return (emailName + "@" + emailDomain), nil
 }
 
 // Email generates random email id

--- a/internet_test.go
+++ b/internet_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-faker/faker/v4/pkg/options"
 	"github.com/go-faker/faker/v4/pkg/slice"
 )
 
@@ -108,6 +109,14 @@ func TestFakeEmail(t *testing.T) {
 		t.Error("Expected  email")
 	}
 }
+
+func TestFakeEmailWithCustomDomain(t *testing.T) {
+	email := Email(options.WithCustomDomain("yopmail.com"))
+	if !strings.Contains(email, "@yopmail.com") {
+		t.Error("Expected  email")
+	}
+}
+
 func TestFakeMacAddress(t *testing.T) {
 	mc := MacAddress()
 	if strings.Count(mc, ":") != 5 {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -61,6 +61,8 @@ type Options struct {
 	RandomFloatBoundary *interfaces.RandomFloatBoundary
 	// SetTagName sets the tag name that should be used
 	TagName string
+	// CustomDomain is used for specifying a custom domain when generating email
+	CustomDomain *string
 }
 
 // MaxDepthOption used for configuring the max depth of nested struct for faker
@@ -124,6 +126,13 @@ func WithFieldsToIgnore(fieldNames ...string) OptionFunc {
 		for _, f := range fieldNames {
 			oo.IgnoreFields[f] = struct{}{}
 		}
+	}
+}
+
+// WithCustomDomain is used to set a custom domain for generating fake email
+func WithCustomDomain(domain string) OptionFunc {
+	return func(oo *Options) {
+		oo.CustomDomain = &domain
 	}
 }
 


### PR DESCRIPTION
### Background
Previously, fake emails were generated with a random domain. This update allows the user to specify a custom domain for the generated email, providing more flexibility for different testing or mock scenarios.

### Summary

- Added support for custom domains when generating fake emails.
- Default behavior remains unchanged if no custom domain is specified.

### Changes

- Introduced `WithCustomDomain` function to set a custom domain.
- Updated fake email generation logic to use the custom domain.

### Impact

- Backward-compatible.
- No breaking changes.