### PR TITLE
Add template tag to enable derived values for string fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ go get -u github.com/go-faker/faker/v4
   - [language: example_with_tags_lang_test.go](/example_with_tags_lang_test.go)
   - [unique: example_with_tags_unique_test.go](example_with_tags_unique_test.go)
   - [slice length: example_with_tags_slicelength_test.go](example_with_tags_slicelength_test.go)
+  - [template (derived fields): example_template_tag_test.go](example_template_tag_test.go)
 - Custom Struct's tag (define your own faker data): [example_custom_faker_test.go](/example_custom_faker_test.go)
 - Without struct's tag: [example_without_tag_test.go](/example_without_tag_test.go)
 - Single Fake Data Function: [example_single_fake_data_test.go](/example_single_fake_data_test.go)
@@ -103,6 +104,7 @@ Unfortunately this library has some limitation
 - It does not support the `map[any]any`, `map[T]any` & `map[any]T` data types (where `T` is any concrete type). Once again, we cannot generate values for an unknown data type.
 - Some extra custom types can be supported IF AND ONLY IF extended with [AddProvider()](https://github.com/go-faker/faker/blob/7473ac7d8d0440d24addac302c73e13c08895764/faker.go#L303) please see [example](example_custom_faker_test.go#L46)
 - The `oneof` tag currently only supports `string`, the `int` types, and both `float32` & `float64`. Further support is coming soon (i.e. hex numbers, etc). See [example](example_with_tags_test.go#L53) for usage.
+- The `template` tag currently only supports `string`, named string types & `*string`, and can only reference the fields of the struct that declares it. See [example](example_template_tag_test.go) for usage.
 
 ## Contribution
 

--- a/example_template_tag_test.go
+++ b/example_template_tag_test.go
@@ -6,20 +6,15 @@ import (
 	"github.com/go-faker/faker/v4"
 )
 
-type Address struct {
-	Street string `faker:"street_name"`
-	City   string `faker:"city"`
-}
-
 type UserProfile struct {
-	FirstName string `faker:"first_name"`
-	LastName  string `faker:"last_name"`
-	Domain    string `faker:"domain"`
+	FirstName  string `faker:"first_name"`
+	LastName   string `faker:"last_name"`
+	DomainName string `faker:"domain_name"`
 
 	// Template uses helper 'lower' and 'slug' (slug is lower+dash)
 	Username string `faker:"template:{{.FirstName | lower}}.{{.LastName | lower}}"`
 	Slug     string `faker:"template:{{.FirstName | slug}}-{{.LastName | slug}}"`
-	Email    string `faker:"template:{{.Username}}@{{.Domain}}"`
+	Email    string `faker:"template:{{.Username}}@{{.DomainName}}"`
 	// (only template-related fields kept for this example)
 }
 

--- a/example_template_tag_test.go
+++ b/example_template_tag_test.go
@@ -14,7 +14,7 @@ type Address struct {
 type UserProfile struct {
 	FirstName string `faker:"first_name"`
 	LastName  string `faker:"last_name"`
-	Domain    string `faker:"domain_name"`
+	Domain    string `faker:"domain"`
 
 	// Template uses helper 'lower' and 'slug' (slug is lower+dash)
 	Username string `faker:"template:{{.FirstName | lower}}.{{.LastName | lower}}"`

--- a/example_template_tag_test.go
+++ b/example_template_tag_test.go
@@ -1,0 +1,34 @@
+package faker_test
+
+import (
+	"fmt"
+
+	"github.com/go-faker/faker/v4"
+)
+
+type Address struct {
+	Street string `faker:"street_name"`
+	City   string `faker:"city"`
+}
+
+type UserProfile struct {
+	FirstName string `faker:"first_name"`
+	LastName  string `faker:"last_name"`
+	Domain    string `faker:"domain_name"`
+
+	// Template uses helper 'lower' and 'slug' (slug is lower+dash)
+	Username string `faker:"template:{{.FirstName | lower}}.{{.LastName | lower}}"`
+	Slug     string `faker:"template:{{.FirstName | slug}}-{{.LastName | slug}}"`
+	Email    string `faker:"template:{{.Username}}@{{.Domain}}"`
+	// (only template-related fields kept for this example)
+}
+
+func Example_templateTag() {
+	var v UserProfile
+	if err := faker.FakeData(&v); err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	// output the filled struct; values are random so we don't assert exact output
+	fmt.Printf("%+v\n", v)
+}

--- a/example_template_tag_test.go
+++ b/example_template_tag_test.go
@@ -4,26 +4,41 @@ import (
 	"fmt"
 
 	"github.com/go-faker/faker/v4"
+	"github.com/go-faker/faker/v4/pkg/options"
 )
 
+// UserProfile derives Username, Slug and Email from the fields faker generates.
+// Note that Email is declared before the Username it reads: template fields are
+// evaluated in dependency order, not declaration order.
 type UserProfile struct {
 	FirstName  string `faker:"first_name"`
 	LastName   string `faker:"last_name"`
 	DomainName string `faker:"domain_name"`
 
-	// Template uses helper 'lower' and 'slug' (slug is lower+dash)
+	Email    string `faker:"template:{{.Username}}@{{.DomainName}}"`
 	Username string `faker:"template:{{.FirstName | lower}}.{{.LastName | lower}}"`
 	Slug     string `faker:"template:{{.FirstName | slug}}-{{.LastName | slug}}"`
-	Email    string `faker:"template:{{.Username}}@{{.DomainName}}"`
-	// (only template-related fields kept for this example)
 }
 
 func Example_templateTag() {
+	// The inputs are pinned so the derived values are reproducible; in real use
+	// you would let faker generate them.
 	var v UserProfile
-	if err := faker.FakeData(&v); err != nil {
+	err := faker.FakeData(&v,
+		options.WithCustomFieldProvider("FirstName", func() (any, error) { return "John", nil }),
+		options.WithCustomFieldProvider("LastName", func() (any, error) { return "Doe", nil }),
+		options.WithCustomFieldProvider("DomainName", func() (any, error) { return "example.org", nil }),
+	)
+	if err != nil {
 		fmt.Println("error:", err)
 		return
 	}
-	// output the filled struct; values are random so we don't assert exact output
-	fmt.Printf("%+v\n", v)
+
+	fmt.Println("Username:", v.Username)
+	fmt.Println("Slug:", v.Slug)
+	fmt.Println("Email:", v.Email)
+	// Output:
+	// Username: john.doe
+	// Slug: john-doe
+	// Email: john.doe@example.org
 }

--- a/faker.go
+++ b/faker.go
@@ -90,6 +90,7 @@ const (
 	comma                     = ","
 	colon                     = ":"
 	ONEOF                     = "oneof"
+	TemplateTag               = "template"
 	RussianFirstNameMaleTag   = "russian_first_name_male"
 	RussianLastNameMaleTag    = "russian_last_name_male"
 	RussianFirstNameFemaleTag = "russian_first_name_female"
@@ -441,6 +442,8 @@ func getFakedValue(item interface{}, opts *options.Options) (reflect.Value, erro
 		}
 		originalDataVal := reflect.ValueOf(item)
 		v := reflect.New(t).Elem()
+		// collect template fields to evaluate in a second pass
+		templateFields := make([]int, 0)
 		if opts.MaxFieldDepthOption == 0 {
 			return v, nil
 		} else if opts.MaxFieldDepthOption > 0 {
@@ -467,6 +470,11 @@ func getFakedValue(item interface{}, opts *options.Options) (reflect.Value, erro
 			}
 
 			tags := decodeTags(t, i, opts.TagName)
+			// if this field is a template tag, defer evaluation until other fields are generated
+			if strings.HasPrefix(strings.ToLower(tags.fieldType), TemplateTag) {
+				templateFields = append(templateFields, i)
+				continue
+			}
 			switch {
 			case tags.keepOriginal:
 				zero, err := isZero(reflect.ValueOf(item).Field(i))
@@ -524,6 +532,12 @@ func getFakedValue(item interface{}, opts *options.Options) (reflect.Value, erro
 				retry = 0
 			}
 
+		}
+		// second pass: evaluate template fields using values generated above
+		if len(templateFields) > 0 {
+			if err := EvaluateTemplateFields(t, v, templateFields, opts.TagName); err != nil {
+				return reflect.Value{}, err
+			}
 		}
 		return v, nil
 

--- a/faker.go
+++ b/faker.go
@@ -471,7 +471,7 @@ func getFakedValue(item interface{}, opts *options.Options) (reflect.Value, erro
 
 			tags := decodeTags(t, i, opts.TagName)
 			// if this field is a template tag, defer evaluation until other fields are generated
-			if strings.HasPrefix(strings.ToLower(tags.fieldType), TemplateTag) {
+			if strings.HasPrefix(strings.ToLower(tags.fieldType), TemplateTag+":") {
 				templateFields = append(templateFields, i)
 				continue
 			}

--- a/faker.go
+++ b/faker.go
@@ -620,8 +620,24 @@ func getFakedValueForStruct(item any, t reflect.Type, opts *options.Options) (re
 		}
 
 		tags := decodeTags(t, i, opts.TagName)
-		// if this field is a template tag, defer evaluation until other fields are generated
-		if strings.HasPrefix(strings.ToLower(tags.fieldType), TemplateTag+":") {
+		// A template field is derived from other fields, so it is deferred to a
+		// second pass that runs once every other field has been generated.
+		if tags.isTemplate {
+			if tags.unique {
+				// A template over fixed inputs is deterministic, so the retry loop
+				// could never produce a different value. Fail loudly instead.
+				return reflect.Value{}, fmt.Errorf(fakerErrors.ErrTemplateWithUnique, t.Field(i).Name)
+			}
+			if tags.keepOriginal {
+				zero, err := isZero(originalDataVal.Field(i))
+				if err != nil {
+					return reflect.Value{}, err
+				}
+				if !zero {
+					v.Field(i).Set(originalDataVal.Field(i))
+					continue
+				}
+			}
 			templateFields = append(templateFields, i)
 			continue
 		}
@@ -684,10 +700,8 @@ func getFakedValueForStruct(item any, t reflect.Type, opts *options.Options) (re
 
 	}
 	// second pass: evaluate template fields using values generated above
-	if len(templateFields) > 0 {
-		if err := EvaluateTemplateFields(t, v, templateFields, opts.TagName); err != nil {
-			return reflect.Value{}, err
-		}
+	if err := evaluateTemplateFields(t, v, templateFields, opts.TagName); err != nil {
+		return reflect.Value{}, err
 	}
 	return v, nil
 }
@@ -713,6 +727,10 @@ func decodeTags(typ reflect.Type, i int, tagName string) structTag {
 	uni := false
 	res := make([]string, 0)
 	pMap := make(map[string]string)
+	// body collects the template body once a "template:" chunk is seen. Everything
+	// after that chunk belongs to the body, so a template may contain commas; only
+	// the standalone "keep" and "unique" chunks keep their usual meaning.
+	var body []string
 	for _, tag := range tags {
 		if tag == keep {
 			keepOriginal = true
@@ -721,11 +739,29 @@ func decodeTags(typ reflect.Type, i int, tagName string) structTag {
 			uni = true
 			continue
 		}
+		if body != nil {
+			body = append(body, tag)
+			continue
+		}
+		if hasTemplatePrefix(strings.TrimSpace(tag)) {
+			body = append(body, strings.TrimSpace(tag)[len(TemplateTag)+1:])
+			continue
+		}
 		// res = append(res, tag)
 		ptag := strings.ToLower(strings.Trim(strings.Split(tag, "=")[0], " "))
 		pMap[ptag] = tag
 		ptag = strings.ToLower(strings.Trim(strings.Split(tag, ":")[0], " "))
 		pMap[ptag] = tag
+	}
+	if body != nil {
+		// A template body is opaque: it must never reach the priority scanner, which
+		// would otherwise hijack a chunk such as ", email: {{.X}}" as the email tag.
+		return structTag{
+			template:     strings.Join(body, comma),
+			isTemplate:   true,
+			unique:       uni,
+			keepOriginal: keepOriginal,
+		}
 	}
 	// Priority
 	for _, ptag := range PriorityTags {
@@ -753,9 +789,22 @@ func decodeTags(typ reflect.Type, i int, tagName string) structTag {
 }
 
 type structTag struct {
-	fieldType    string
+	fieldType string
+	// template holds the verbatim template body when isTemplate is set. It is kept
+	// out of fieldType because a template body is not a tag and must not be parsed
+	// as one.
+	template     string
 	unique       bool
 	keepOriginal bool
+	isTemplate   bool
+}
+
+// hasTemplatePrefix reports whether s starts with "template:" (case-insensitive).
+// The colon is required, so `faker:"template"` and `faker:"templated"` stay with
+// the normal tag pipeline.
+func hasTemplatePrefix(s string) bool {
+	const n = len(TemplateTag) + 1
+	return len(s) >= n && strings.EqualFold(s[:n], TemplateTag+colon)
 }
 
 func setDataWithTag(v reflect.Value, tag string, opt options.Options) error {

--- a/faker.go
+++ b/faker.go
@@ -91,6 +91,7 @@ const (
 	comma                      = ","
 	colon                      = ":"
 	ONEOF                      = "oneof"
+	TemplateTag                = "template"
 	RussianFirstNameMaleTag    = "russian_first_name_male"
 	RussianMiddleNameMaleTag   = "russian_middle_name_male"
 	RussianLastNameMaleTag     = "russian_last_name_male"
@@ -586,6 +587,8 @@ func getFakedValueForStruct(item any, t reflect.Type, opts *options.Options) (re
 	}
 	originalDataVal := reflect.ValueOf(item)
 	v := reflect.New(t).Elem()
+	// collect template fields to evaluate in a second pass
+	var templateFields []int
 	if opts.MaxFieldDepthOption == 0 {
 		return v, nil
 	} else if opts.MaxFieldDepthOption > 0 {
@@ -617,6 +620,11 @@ func getFakedValueForStruct(item any, t reflect.Type, opts *options.Options) (re
 		}
 
 		tags := decodeTags(t, i, opts.TagName)
+		// if this field is a template tag, defer evaluation until other fields are generated
+		if strings.HasPrefix(strings.ToLower(tags.fieldType), TemplateTag) {
+			templateFields = append(templateFields, i)
+			continue
+		}
 		switch {
 		case tags.keepOriginal:
 			zero, err := isZero(reflect.ValueOf(item).Field(i))
@@ -674,6 +682,12 @@ func getFakedValueForStruct(item any, t reflect.Type, opts *options.Options) (re
 			retry = 0
 		}
 
+	}
+	// second pass: evaluate template fields using values generated above
+	if len(templateFields) > 0 {
+		if err := EvaluateTemplateFields(t, v, templateFields, opts.TagName); err != nil {
+			return reflect.Value{}, err
+		}
 	}
 	return v, nil
 }

--- a/faker.go
+++ b/faker.go
@@ -621,7 +621,7 @@ func getFakedValueForStruct(item any, t reflect.Type, opts *options.Options) (re
 
 		tags := decodeTags(t, i, opts.TagName)
 		// if this field is a template tag, defer evaluation until other fields are generated
-		if strings.HasPrefix(strings.ToLower(tags.fieldType), TemplateTag) {
+		if strings.HasPrefix(strings.ToLower(tags.fieldType), TemplateTag+":") {
 			templateFields = append(templateFields, i)
 			continue
 		}

--- a/pkg/errors/generic.go
+++ b/pkg/errors/generic.go
@@ -10,6 +10,12 @@ package errors
 //	ErrTagDoesNotExist: Error when tag does not exist and call RemoveProvider
 //	ErrMoreArguments: Error on passing more arguments
 //	ErrNotSupportedPointer: Error when passing unsupported pointer
+//	ErrTemplateNotStringField: Error when the template tag is used on a non-string field
+//	ErrTemplateEmptyBody: Error when the template tag has no body
+//	ErrTemplateParse: Error when the template body fails to parse
+//	ErrTemplateEvaluate: Error when the template body fails to execute
+//	ErrTemplateCycle: Error when template fields reference each other in a cycle
+//	ErrTemplateWithUnique: Error when the template tag is combined with the unique tag
 var (
 	ErrUnsupportedKindPtr        = "Unsupported kind: %s Change Without using * (pointer) in Field of %s"
 	ErrUnsupportedKind           = "Unsupported kind: %s"
@@ -33,4 +39,11 @@ var (
 	ErrNotEnoughTagArguments   = "Not enough arguments for tag."
 	ErrUnsupportedNumberType   = "Unsupported Number type."
 	ErrOnlyStructTypeSupported = "only struct type supported."
+
+	ErrTemplateNotStringField = "Template tag is only supported on string fields, field \"%s\" is %s"
+	ErrTemplateEmptyBody      = "Template tag for field \"%s\" has an empty body"
+	ErrTemplateParse          = "Failed to parse template for field \"%s\": %w"
+	ErrTemplateEvaluate       = "Failed to evaluate template for field \"%s\": %w"
+	ErrTemplateCycle          = "Template tag cycle detected: %s"
+	ErrTemplateWithUnique     = "Tag \"unique\" can not be combined with the template tag (field \"%s\")"
 )

--- a/template_tag.go
+++ b/template_tag.go
@@ -15,6 +15,8 @@ func EvaluateTemplateFields(t reflect.Type, v reflect.Value, templateFields []in
 		return nil
 	}
 	// build context map from current struct values
+	// this will be updated as we compute each template field so
+	// later templates can reference earlier template results.
 	ctx := make(map[string]any)
 	for i := 0; i < v.NumField(); i++ {
 		ctx[t.Field(i).Name] = v.Field(i).Interface()
@@ -34,7 +36,10 @@ func EvaluateTemplateFields(t reflect.Type, v reflect.Value, templateFields []in
 		if v.Field(idx).Kind() != reflect.String {
 			return fmt.Errorf("template tag only supported on string fields: %s", t.Field(idx).Name)
 		}
+
 		v.Field(idx).SetString(res)
+		//  update context so subsequent template fields can reference it
+		ctx[t.Field(idx).Name] = res
 	}
 	return nil
 }

--- a/template_tag.go
+++ b/template_tag.go
@@ -4,9 +4,14 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 	"text/template"
 )
+
+// fieldRefRegexp matches references to struct fields in a template body, e.g. `.FieldName`.
+// Field names in Go are exported (start with uppercase), so we only consider those.
+var fieldRefRegexp = regexp.MustCompile(`\.([A-Z]\w*)`)
 
 // EvaluateTemplateFields evaluates the template-tagged fields for a struct value `v` of type `t`.
 // tagName is the field tag name to use (typically opts.TagName).
@@ -22,12 +27,31 @@ func EvaluateTemplateFields(t reflect.Type, v reflect.Value, templateFields []in
 		ctx[t.Field(i).Name] = v.Field(i).Interface()
 	}
 
+	// Build the set of all template-field names and track which have been
+	// evaluated so we can detect forward / circular references.
+	templateFieldNames := make(map[string]bool, len(templateFields))
+	for _, idx := range templateFields {
+		templateFieldNames[t.Field(idx).Name] = true
+	}
+	evaluated := make(map[string]bool, len(templateFields))
+
 	for _, idx := range templateFields {
 		tags := decodeTags(t, idx, tagName)
 		tpl := tags.fieldType
 		lower := strings.ToLower(tpl)
 		if strings.HasPrefix(lower, TemplateTag+":") {
 			tpl = tpl[len(TemplateTag)+1:]
+		}
+		fieldName := t.Field(idx).Name
+		// Reject forward / circular references to other template fields.
+		for _, m := range fieldRefRegexp.FindAllStringSubmatch(tpl, -1) {
+			ref := m[1]
+			if ref == fieldName {
+				return fmt.Errorf("template field %q references itself", fieldName)
+			}
+			if templateFieldNames[ref] && !evaluated[ref] {
+				return fmt.Errorf("template field %q references template field %q which has not been evaluated yet (forward or circular reference)", fieldName, ref)
+			}
 		}
 		res, err := evaluateTemplateForField(tpl, ctx)
 		if err != nil {
@@ -39,7 +63,8 @@ func EvaluateTemplateFields(t reflect.Type, v reflect.Value, templateFields []in
 
 		v.Field(idx).SetString(res)
 		//  update context so subsequent template fields can reference it
-		ctx[t.Field(idx).Name] = res
+		ctx[fieldName] = res
+		evaluated[fieldName] = true
 	}
 	return nil
 }
@@ -47,7 +72,7 @@ func EvaluateTemplateFields(t reflect.Type, v reflect.Value, templateFields []in
 // evaluateTemplateForField evaluates a template string tpl with context ctx (map of field name -> value)
 // and returns the resulting string. Only a small set of helper funcs are exposed.
 func evaluateTemplateForField(tpl string, ctx map[string]any) (string, error) {
-	t, err := template.New("faker_template").Funcs(helpers()).Parse(tpl)
+	t, err := template.New("faker_template").Option("missingkey=error").Funcs(helpers()).Parse(tpl)
 	if err != nil {
 		return "", err
 	}

--- a/template_tag.go
+++ b/template_tag.go
@@ -15,7 +15,7 @@ func EvaluateTemplateFields(t reflect.Type, v reflect.Value, templateFields []in
 		return nil
 	}
 	// build context map from current struct values
-	ctx := make(map[string]interface{})
+	ctx := make(map[string]any)
 	for i := 0; i < v.NumField(); i++ {
 		ctx[t.Field(i).Name] = v.Field(i).Interface()
 	}
@@ -41,7 +41,7 @@ func EvaluateTemplateFields(t reflect.Type, v reflect.Value, templateFields []in
 
 // evaluateTemplateForField evaluates a template string tpl with context ctx (map of field name -> value)
 // and returns the resulting string. Only a small set of helper funcs are exposed.
-func evaluateTemplateForField(tpl string, ctx map[string]interface{}) (string, error) {
+func evaluateTemplateForField(tpl string, ctx map[string]any) (string, error) {
 	t, err := template.New("faker_template").Funcs(helpers()).Parse(tpl)
 	if err != nil {
 		return "", err

--- a/template_tag.go
+++ b/template_tag.go
@@ -1,0 +1,84 @@
+package faker
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"strings"
+	"text/template"
+)
+
+// EvaluateTemplateFields evaluates the template-tagged fields for a struct value `v` of type `t`.
+// tagName is the field tag name to use (typically opts.TagName).
+func EvaluateTemplateFields(t reflect.Type, v reflect.Value, templateFields []int, tagName string) error {
+	if len(templateFields) == 0 {
+		return nil
+	}
+	// build context map from current struct values
+	ctx := make(map[string]interface{})
+	for i := 0; i < v.NumField(); i++ {
+		ctx[t.Field(i).Name] = v.Field(i).Interface()
+	}
+
+	for _, idx := range templateFields {
+		tags := decodeTags(t, idx, tagName)
+		tpl := tags.fieldType
+		lower := strings.ToLower(tpl)
+		if strings.HasPrefix(lower, TemplateTag+":") {
+			tpl = tpl[len(TemplateTag)+1:]
+		}
+		res, err := evaluateTemplateForField(tpl, ctx)
+		if err != nil {
+			return err
+		}
+		if v.Field(idx).Kind() != reflect.String {
+			return fmt.Errorf("template tag only supported on string fields: %s", t.Field(idx).Name)
+		}
+		v.Field(idx).SetString(res)
+	}
+	return nil
+}
+
+// evaluateTemplateForField evaluates a template string tpl with context ctx (map of field name -> value)
+// and returns the resulting string. Only a small set of helper funcs are exposed.
+func evaluateTemplateForField(tpl string, ctx map[string]interface{}) (string, error) {
+	t, err := template.New("faker_template").Funcs(helpers()).Parse(tpl)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, ctx); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func helpers() template.FuncMap {
+	return template.FuncMap{
+		"lower": strings.ToLower,
+		"upper": strings.ToUpper,
+		"slug":  func(s string) string { return slugify(s) },
+		//can add more
+	}
+}
+
+// slugify is a tiny, permissive slug function: lowercases and replaces non-alphanumeric with '-'
+func slugify(s string) string {
+	var b strings.Builder
+	s = strings.ToLower(s)
+	lastDash := false
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	res := b.String()
+	res = strings.Trim(res, "-")
+	return res
+}

--- a/template_tag.go
+++ b/template_tag.go
@@ -1,114 +1,342 @@
 package faker
 
+// The template tag (`faker:"template:{{.Other}}"`) derives a field's value from
+// other fields of the same struct. Because a template reads values that faker
+// itself generates, template fields are filled in a second pass that runs after
+// every other field of the struct is done — see getFakedValueForStruct.
+//
+// Within that second pass, template fields are evaluated in dependency order
+// rather than declaration order, so a template may reference another template
+// field declared later. Only a true cycle is an error.
+//
+// TemplateTag is deliberately absent from PriorityTags: it is not a provider, and
+// listing it there would route the tag through setDataWithTag.
+
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"reflect"
-	"regexp"
 	"strings"
 	"text/template"
+	"text/template/parse"
+	"unicode"
+
+	fakerErrors "github.com/go-faker/faker/v4/pkg/errors"
 )
 
-// fieldRefRegexp matches references to struct fields in a template body, e.g. `.FieldName`.
-// Field names in Go are exported (start with uppercase), so we only consider those.
-var fieldRefRegexp = regexp.MustCompile(`\.([A-Z]\w*)`)
+// templateField is one parsed, validated template-tagged field of a struct.
+type templateField struct {
+	index int    // index of the field within the struct
+	name  string // field name, used in error messages
+	tpl   *template.Template
+	deps  []int // positions within templatePlan.fields this field depends on
+}
 
-// EvaluateTemplateFields evaluates the template-tagged fields for a struct value `v` of type `t`.
-// tagName is the field tag name to use (typically opts.TagName).
-func EvaluateTemplateFields(t reflect.Type, v reflect.Value, templateFields []int, tagName string) error {
-	if len(templateFields) == 0 {
+// templatePlan is the validated evaluation plan for the template fields of one
+// struct type.
+type templatePlan struct {
+	fields []templateField // declaration order
+	order  []int           // positions within fields, in dependency order
+}
+
+// evaluateTemplateFields fills the template-tagged fields of v listed in fields.
+// v must be an addressable struct value of type t. fields holds struct field
+// indices collected by the first pass; a template field missing from it was
+// handled by a higher-precedence option (IgnoreFields, OnlyZeroFields,
+// FieldProviders, keep) and is left alone.
+func evaluateTemplateFields(t reflect.Type, v reflect.Value, fields []int, tagName string) error {
+	if len(fields) == 0 {
 		return nil
 	}
-	// build context map from current struct values
-	// this will be updated as we compute each template field so
-	// later templates can reference earlier template results.
-	ctx := make(map[string]any)
-	for i := 0; i < v.NumField(); i++ {
-		ctx[t.Field(i).Name] = v.Field(i).Interface()
+	if !v.CanAddr() {
+		return errors.New(fakerErrors.ErrValueNotPtr)
 	}
-
-	// Build the set of all template-field names and track which have been
-	// evaluated so we can detect forward / circular references.
-	templateFieldNames := make(map[string]bool, len(templateFields))
-	for _, idx := range templateFields {
-		templateFieldNames[t.Field(idx).Name] = true
+	plan, err := buildTemplatePlan(t, tagName)
+	if err != nil {
+		return err
 	}
-	evaluated := make(map[string]bool, len(templateFields))
-
-	for _, idx := range templateFields {
-		tags := decodeTags(t, idx, tagName)
-		tpl := tags.fieldType
-		lower := strings.ToLower(tpl)
-		if strings.HasPrefix(lower, TemplateTag+":") {
-			tpl = tpl[len(TemplateTag)+1:]
+	// Templates read the struct itself rather than a map built by reflection. That
+	// is what makes unexported fields safe: text/template reports them as an error
+	// instead of us panicking on reflect.Value.Interface. Taking the address means
+	// each template also sees the results written by earlier ones.
+	data := v.Addr().Interface()
+	var buf bytes.Buffer
+	for _, p := range plan.order {
+		tf := &plan.fields[p]
+		if !containsFieldIndex(fields, tf.index) {
+			continue
 		}
-		fieldName := t.Field(idx).Name
-		// Reject forward / circular references to other template fields.
-		for _, m := range fieldRefRegexp.FindAllStringSubmatch(tpl, -1) {
-			ref := m[1]
-			if ref == fieldName {
-				return fmt.Errorf("template field %q references itself", fieldName)
-			}
-			if templateFieldNames[ref] && !evaluated[ref] {
-				return fmt.Errorf("template field %q references template field %q which has not been evaluated yet (forward or circular reference)", fieldName, ref)
-			}
+		buf.Reset()
+		if err := tf.tpl.Execute(&buf, data); err != nil {
+			return fmt.Errorf(fakerErrors.ErrTemplateEvaluate, tf.name, err)
 		}
-		res, err := evaluateTemplateForField(tpl, ctx)
-		if err != nil {
-			return err
-		}
-		if v.Field(idx).Kind() != reflect.String {
-			return fmt.Errorf("template tag only supported on string fields: %s", t.Field(idx).Name)
-		}
-
-		v.Field(idx).SetString(res)
-		//  update context so subsequent template fields can reference it
-		ctx[fieldName] = res
-		evaluated[fieldName] = true
+		setTemplateResult(v.Field(tf.index), buf.String())
 	}
 	return nil
 }
 
-// evaluateTemplateForField evaluates a template string tpl with context ctx (map of field name -> value)
-// and returns the resulting string. Only a small set of helper funcs are exposed.
-func evaluateTemplateForField(tpl string, ctx map[string]any) (string, error) {
-	t, err := template.New("faker_template").Option("missingkey=error").Funcs(helpers()).Parse(tpl)
-	if err != nil {
-		return "", err
+func containsFieldIndex(fields []int, idx int) bool {
+	for _, f := range fields {
+		if f == idx {
+			return true
+		}
 	}
-	var buf bytes.Buffer
-	if err := t.Execute(&buf, ctx); err != nil {
-		return "", err
-	}
-	return buf.String(), nil
+	return false
 }
 
-func helpers() template.FuncMap {
-	return template.FuncMap{
-		"lower": strings.ToLower,
-		"upper": strings.ToUpper,
-		"slug":  func(s string) string { return slugify(s) },
-		//can add more
-	}
-}
+// buildTemplatePlan parses and validates every template-tagged field of t and
+// works out the order they must be evaluated in.
+func buildTemplatePlan(t reflect.Type, tagName string) (*templatePlan, error) {
+	plan := &templatePlan{}
+	posByName := make(map[string]int)
 
-// slugify is a tiny, permissive slug function: lowercases and replaces non-alphanumeric with '-'
-func slugify(s string) string {
-	var b strings.Builder
-	s = strings.ToLower(s)
-	lastDash := false
-	for _, r := range s {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
-			b.WriteRune(r)
-			lastDash = false
+	for i := range t.NumField() {
+		f := t.Field(i)
+		if !f.IsExported() {
 			continue
 		}
-		if !lastDash {
+		tags := decodeTags(t, i, tagName)
+		if !tags.isTemplate {
+			continue
+		}
+		// Validate the destination before anything is evaluated, so a bad tag can
+		// never leave some fields written and others not.
+		if !templateAssignable(f.Type) {
+			return nil, fmt.Errorf(fakerErrors.ErrTemplateNotStringField, f.Name, f.Type)
+		}
+		if strings.TrimSpace(tags.template) == "" {
+			return nil, fmt.Errorf(fakerErrors.ErrTemplateEmptyBody, f.Name)
+		}
+		tpl, err := template.New(f.Name).Funcs(templateHelpers).Parse(tags.template)
+		if err != nil {
+			return nil, fmt.Errorf(fakerErrors.ErrTemplateParse, f.Name, err)
+		}
+		posByName[f.Name] = len(plan.fields)
+		plan.fields = append(plan.fields, templateField{index: i, name: f.Name, tpl: tpl})
+	}
+	if len(plan.fields) == 0 {
+		return plan, nil
+	}
+
+	// Only references to other template fields become edges. References to ordinary
+	// fields need no ordering: the first pass already filled them.
+	for p := range plan.fields {
+		for _, ref := range templateFieldRefs(plan.fields[p].tpl.Tree) {
+			if q, ok := posByName[ref]; ok {
+				plan.fields[p].deps = append(plan.fields[p].deps, q)
+			}
+		}
+	}
+
+	order, err := topoSortTemplateFields(plan.fields)
+	if err != nil {
+		return nil, err
+	}
+	plan.order = order
+	return plan, nil
+}
+
+// templateAssignable reports whether the template result can be stored in a field
+// of type t. Named string types work through SetString; *string is allocated.
+func templateAssignable(t reflect.Type) bool {
+	return t.Kind() == reflect.String ||
+		(t.Kind() == reflect.Pointer && t.Elem().Kind() == reflect.String)
+}
+
+func setTemplateResult(f reflect.Value, s string) {
+	if f.Kind() == reflect.Pointer {
+		p := reflect.New(f.Type().Elem())
+		p.Elem().SetString(s)
+		f.Set(p)
+		return
+	}
+	f.SetString(s)
+}
+
+// templateFieldRefs returns the names of the struct fields a template reads, in
+// source order and deduplicated.
+//
+// It walks the parse tree rather than matching the template source with a regular
+// expression: only the tree can tell a field reference from literal text such as
+// "@Example.Com", can report `{{.Addr.City}}` as a reference to Addr alone, and
+// can tell that the dot inside a `range` or `with` body is the loop value rather
+// than the struct.
+func templateFieldRefs(tree *parse.Tree) []string {
+	if tree == nil || tree.Root == nil {
+		return nil
+	}
+	var out []string
+	seen := make(map[string]struct{})
+	add := func(name string) {
+		if _, ok := seen[name]; !ok {
+			seen[name] = struct{}{}
+			out = append(out, name)
+		}
+	}
+	var walk func(parse.Node)
+	// walkBranch handles if/range/with. The controlling pipe is always evaluated
+	// with the outer dot; range and with rebind dot for their body, so the body
+	// cannot reference our struct's fields. An else body runs with the outer dot.
+	walkBranch := func(b *parse.BranchNode, rebindsDot bool) {
+		walk(b.Pipe)
+		if !rebindsDot && b.List != nil {
+			walk(b.List)
+		}
+		if b.ElseList != nil {
+			walk(b.ElseList)
+		}
+	}
+	walk = func(n parse.Node) {
+		switch n := n.(type) {
+		case *parse.ListNode:
+			if n == nil {
+				return
+			}
+			for _, c := range n.Nodes {
+				walk(c)
+			}
+		case *parse.ActionNode:
+			walk(n.Pipe)
+		case *parse.PipeNode:
+			if n == nil {
+				return
+			}
+			for _, d := range n.Decl {
+				walk(d)
+			}
+			for _, c := range n.Cmds {
+				walk(c)
+			}
+		case *parse.CommandNode:
+			for _, a := range n.Args {
+				walk(a)
+			}
+		case *parse.FieldNode:
+			if len(n.Ident) > 0 {
+				add(n.Ident[0])
+			}
+		case *parse.ChainNode:
+			if _, isDot := n.Node.(*parse.DotNode); isDot && len(n.Field) > 0 {
+				add(n.Field[0])
+			}
+			walk(n.Node)
+		case *parse.IfNode:
+			walkBranch(&n.BranchNode, false)
+		case *parse.RangeNode:
+			walkBranch(&n.BranchNode, true)
+		case *parse.WithNode:
+			walkBranch(&n.BranchNode, true)
+		case *parse.TemplateNode:
+			walk(n.Pipe)
+		}
+	}
+	walk(tree.Root)
+	return out
+}
+
+// topoSortTemplateFields returns the positions of fields in dependency order:
+// every field appears after the template fields it references. Roots are visited
+// in declaration order so the result is deterministic. A cycle, including a field
+// that references itself, is an error.
+func topoSortTemplateFields(fields []templateField) ([]int, error) {
+	const (
+		white = iota
+		grey
+		black
+	)
+	state := make([]int8, len(fields))
+	order := make([]int, 0, len(fields))
+	stack := make([]int, 0, len(fields))
+
+	var visit func(p int) error
+	visit = func(p int) error {
+		switch state[p] {
+		case black:
+			return nil
+		case grey:
+			return fmt.Errorf(fakerErrors.ErrTemplateCycle, cyclePath(fields, stack, p))
+		}
+		state[p] = grey
+		stack = append(stack, p)
+		for _, d := range fields[p].deps {
+			if err := visit(d); err != nil {
+				return err
+			}
+		}
+		stack = stack[:len(stack)-1]
+		state[p] = black
+		order = append(order, p)
+		return nil
+	}
+	for p := range fields {
+		if err := visit(p); err != nil {
+			return nil, err
+		}
+	}
+	return order, nil
+}
+
+// cyclePath renders a cycle as "A -> B -> A", starting from where p first appears
+// on the visit stack.
+func cyclePath(fields []templateField, stack []int, p int) string {
+	start := 0
+	for i, s := range stack {
+		if s == p {
+			start = i
+			break
+		}
+	}
+	names := make([]string, 0, len(stack)-start+1)
+	for _, s := range stack[start:] {
+		names = append(names, fields[s].name)
+	}
+	names = append(names, fields[p].name)
+	return strings.Join(names, " -> ")
+}
+
+// templateHelpers is read-only after initialization and shared by every template.
+var templateHelpers = template.FuncMap{
+	"lower": func(v any) string { return strings.ToLower(templateString(v)) },
+	"upper": func(v any) string { return strings.ToUpper(templateString(v)) },
+	"trim":  func(v any) string { return strings.TrimSpace(templateString(v)) },
+	"slug":  func(v any) string { return slugify(templateString(v)) },
+}
+
+// templateString coerces a template argument to a string so the helpers also work
+// on named string types, numbers and fmt.Stringer values.
+func templateString(v any) string {
+	switch s := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return s
+	case fmt.Stringer:
+		return s.String()
+	}
+	if rv := reflect.ValueOf(v); rv.Kind() == reflect.String {
+		return rv.String()
+	}
+	return fmt.Sprint(v)
+}
+
+// slugify lowercases s and replaces each run of non-alphanumeric characters with
+// a single dash, trimming dashes from both ends. Letters and digits of any script
+// are kept, so names generated by the Chinese and Russian providers survive.
+func slugify(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	lastDash := false
+	for _, r := range s {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(r)
+			lastDash = false
+		case !lastDash:
 			b.WriteByte('-')
 			lastDash = true
 		}
 	}
-	res := b.String()
-	res = strings.Trim(res, "-")
-	return res
+	return strings.Trim(b.String(), "-")
 }

--- a/template_tag_test.go
+++ b/template_tag_test.go
@@ -5,6 +5,33 @@ import (
 	"testing"
 )
 
+// TestTemplateTagPrefixParsing ensures that only tags of the form `template:...`
+// are treated as template fields. Tags whose name merely begins with the substring
+// "template" (e.g. `templated`) or the bare word `template` without a colon must
+// not be hijacked by the template-tag pipeline.
+func TestTemplateTagPrefixParsing(t *testing.T) {
+	// Bare "template" with no colon: not a template field. Should fall through
+	// to the normal tag pipeline, which has no provider named "template" and
+	// must therefore return an error rather than silently producing "template".
+	type NoColon struct {
+		X string `faker:"template"`
+	}
+	var n NoColon
+	if err := FakeData(&n); err == nil && n.X == "template" {
+		t.Fatalf("bare 'template' tag was incorrectly treated as a template field, got X=%q", n.X)
+	}
+
+	// "templated" shares a prefix with "template" but is a distinct (unknown) tag.
+	// It must not be routed through the template engine.
+	type FalsePrefix struct {
+		X string `faker:"templated"`
+	}
+	var f FalsePrefix
+	if err := FakeData(&f); err == nil && f.X == "templated" {
+		t.Fatalf("'templated' tag was incorrectly treated as a template field, got X=%q", f.X)
+	}
+}
+
 func TestEvaluateTemplateFields(t *testing.T) {
 	cases := []struct {
 		name        string
@@ -103,6 +130,54 @@ func TestEvaluateTemplateFields(t *testing.T) {
 				type T struct {
 					Name string
 					Age  int `faker:"template:{{.Name}}"`
+				}
+				var inst T
+				inst.Name = "John"
+				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{1}
+			},
+			expectErr: true,
+		},
+		{
+			name: "circular-reference",
+			setup: func() (reflect.Type, reflect.Value, []int) {
+				type T struct {
+					A string `faker:"template:{{.B}}-x"`
+					B string `faker:"template:{{.A}}-y"`
+				}
+				var inst T
+				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{0, 1}
+			},
+			expectErr: true,
+		},
+		{
+			name: "self-reference",
+			setup: func() (reflect.Type, reflect.Value, []int) {
+				type T struct {
+					A string `faker:"template:{{.A}}-x"`
+				}
+				var inst T
+				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{0}
+			},
+			expectErr: true,
+		},
+		{
+			name: "forward-reference",
+			setup: func() (reflect.Type, reflect.Value, []int) {
+				type T struct {
+					A string `faker:"template:{{.B}}"`
+					B string `faker:"template:hello"`
+				}
+				var inst T
+				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{0, 1}
+			},
+			expectErr: true,
+		},
+		{
+			name: "missing-field-reference",
+			setup: func() (reflect.Type, reflect.Value, []int) {
+				type T struct {
+					Name string
+					Bad  string `faker:"template:{{.DoesNotExist}}"`
 				}
 				var inst T
 				inst.Name = "John"

--- a/template_tag_test.go
+++ b/template_tag_test.go
@@ -1,0 +1,149 @@
+package faker
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEvaluateTemplateFields(t *testing.T) {
+	cases := []struct {
+		name        string
+		setup       func() (reflect.Type, reflect.Value, []int)
+		expectErr   bool
+		expectCheck func() error
+	}{
+		{
+			name: "email-lower",
+			setup: func() (reflect.Type, reflect.Value, []int) {
+				type T struct {
+					Name  string
+					Email string `faker:"template:{{.Name | lower}}@example.com"`
+				}
+				var inst T
+				inst.Name = "John"
+				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{1}
+			},
+			expectErr: false,
+			expectCheck: func() error {
+				return nil
+			},
+		},
+		{
+			name: "multiple",
+			setup: func() (reflect.Type, reflect.Value, []int) {
+				type T struct {
+					Name     string
+					Email    string `faker:"template:{{.Name | lower}}@example.com"`
+					Username string `faker:"template:{{.Name | lower}}"`
+				}
+				var inst T
+				inst.Name = "John"
+				// template fields are at indices 1 and 2
+				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{1, 2}
+			},
+			expectErr: false,
+		},
+		{
+			name: "chained",
+			setup: func() (reflect.Type, reflect.Value, []int) {
+				type T struct {
+					Name  string
+					Slug  string `faker:"template:{{.Name | slug}}"`
+					Email string `faker:"template:{{.Slug}}@example.com"`
+				}
+				var inst T
+				inst.Name = "John"
+				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{1, 2}
+			},
+			expectErr: false,
+		},
+		{
+			name: "slug",
+			setup: func() (reflect.Type, reflect.Value, []int) {
+				type T struct {
+					Name string
+					Slug string `faker:"template:{{.Name | slug}}"`
+				}
+				var inst T
+				inst.Name = "Hello, World!"
+				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{1}
+			},
+			expectErr: false,
+		},
+		{
+			name: "nested",
+			setup: func() (reflect.Type, reflect.Value, []int) {
+				type Addr struct{ City string }
+				type T struct {
+					Addr Addr
+					Desc string `faker:"template:City is {{.Addr.City}}"`
+				}
+				var inst T
+				inst.Addr.City = "Jakarta"
+				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{1}
+			},
+			expectErr: false,
+		},
+		{
+			name: "order",
+			setup: func() (reflect.Type, reflect.Value, []int) {
+				type T struct {
+					Email string `faker:"template:{{.Name | lower}}@example.com"`
+					Name  string
+				}
+				var inst T
+				inst.Name = "John"
+				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{0}
+			},
+			expectErr: false,
+		},
+		{
+			name: "nonstring-error",
+			setup: func() (reflect.Type, reflect.Value, []int) {
+				type T struct {
+					Name string
+					Age  int `faker:"template:{{.Name}}"`
+				}
+				var inst T
+				inst.Name = "John"
+				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{1}
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rt, rv, fields := c.setup()
+			err := EvaluateTemplateFields(rt, rv, fields, "faker")
+			if c.expectErr {
+				if err == nil {
+					t.Fatalf("expected error for case %s", c.name)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for case %s: %v", c.name, err)
+			}
+			// basic sanity checks per-case
+			switch c.name {
+			case "email-lower":
+				if rv.Field(1).String() != "john@example.com" {
+					t.Fatalf("email-lower mismatch: %q", rv.Field(1).String())
+				}
+			case "slug":
+				if rv.Field(1).String() != "hello-world" {
+					t.Fatalf("slug mismatch: %q", rv.Field(1).String())
+				}
+			case "nested":
+				if rv.Field(1).String() != "City is Jakarta" {
+					t.Fatalf("nested mismatch: %q", rv.Field(1).String())
+				}
+			case "order":
+				if rv.Field(0).String() != "john@example.com" {
+					t.Fatalf("order mismatch: %q", rv.Field(0).String())
+				}
+			}
+		})
+	}
+}

--- a/template_tag_test.go
+++ b/template_tag_test.go
@@ -1,224 +1,931 @@
 package faker
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
+	"text/template"
+
+	fakerErrors "github.com/go-faker/faker/v4/pkg/errors"
+	"github.com/go-faker/faker/v4/pkg/options"
 )
+
+// bodyA is the template body shared by most TestDecodeTagsTemplate cases.
+const bodyA = "{{.A}}"
+
+// tagOf decodes the faker tag of the last field of the struct type of sample.
+func tagOf(t *testing.T, sample any) structTag {
+	t.Helper()
+	typ := reflect.TypeOf(sample)
+	return decodeTags(typ, typ.NumField()-1, "faker")
+}
+
+// TestDecodeTagsTemplate guards the tag parser against the ways a template body
+// used to be mangled: commas splitting it, a chunk being mistaken for a priority
+// tag, and keep/unique blanking the whole tag.
+func TestDecodeTagsTemplate(t *testing.T) {
+	cases := []struct {
+		name         string
+		sample       any
+		isTemplate   bool
+		template     string
+		fieldType    string
+		unique       bool
+		keepOriginal bool
+	}{
+		{
+			name: "plain",
+			sample: struct {
+				X string `faker:"template:{{.A}}"`
+			}{},
+			isTemplate: true, template: bodyA,
+		},
+		{
+			name: "case_insensitive_prefix",
+			sample: struct {
+				X string `faker:"Template:{{.A}}"`
+			}{},
+			isTemplate: true, template: bodyA,
+		},
+		{
+			name: "bare_without_colon_is_not_a_template",
+			sample: struct {
+				X string `faker:"template"`
+			}{},
+			fieldType: "template",
+		},
+		{
+			name: "false_prefix_is_not_a_template",
+			sample: struct {
+				X string `faker:"templated"`
+			}{},
+			fieldType: "templated",
+		},
+		{
+			name: "comma_in_body_is_preserved",
+			sample: struct {
+				X string `faker:"template:{{.A}}, {{.B}}"`
+			}{},
+			isTemplate: true, template: "{{.A}}, {{.B}}",
+		},
+		{
+			// A chunk after a comma used to be matched against PriorityTags, which
+			// replaced the whole template with a bogus "email" tag.
+			name: "comma_chunk_is_not_hijacked_by_priority_tags",
+			sample: struct {
+				X string `faker:"template:{{.A}}, email: {{.B}}"`
+			}{},
+			isTemplate: true, template: "{{.A}}, email: {{.B}}",
+		},
+		{
+			name: "trailing_unique",
+			sample: struct {
+				X string `faker:"template:{{.A}},unique"`
+			}{},
+			isTemplate: true, template: bodyA, unique: true,
+		},
+		{
+			name: "trailing_keep",
+			sample: struct {
+				X string `faker:"template:{{.A}},keep"`
+			}{},
+			isTemplate: true, template: bodyA, keepOriginal: true,
+		},
+		{
+			name: "leading_unique",
+			sample: struct {
+				X string `faker:"unique,template:{{.A}}"`
+			}{},
+			isTemplate: true, template: bodyA, unique: true,
+		},
+		{
+			name: "empty_body",
+			sample: struct {
+				X string `faker:"template:"`
+			}{},
+			isTemplate: true, template: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := tagOf(t, c.sample)
+			if got.isTemplate != c.isTemplate {
+				t.Fatalf("isTemplate = %v, want %v (%+v)", got.isTemplate, c.isTemplate, got)
+			}
+			if got.template != c.template {
+				t.Errorf("template = %q, want %q", got.template, c.template)
+			}
+			if got.unique != c.unique {
+				t.Errorf("unique = %v, want %v", got.unique, c.unique)
+			}
+			if got.keepOriginal != c.keepOriginal {
+				t.Errorf("keepOriginal = %v, want %v", got.keepOriginal, c.keepOriginal)
+			}
+			if c.isTemplate {
+				if got.fieldType != "" {
+					t.Errorf("fieldType = %q, want empty for a template tag", got.fieldType)
+				}
+			} else if got.fieldType != c.fieldType {
+				t.Errorf("fieldType = %q, want %q", got.fieldType, c.fieldType)
+			}
+		})
+	}
+}
 
 // TestTemplateTagPrefixParsing ensures that only tags of the form `template:...`
 // are treated as template fields. Tags whose name merely begins with the substring
 // "template" (e.g. `templated`) or the bare word `template` without a colon must
 // not be hijacked by the template-tag pipeline.
 func TestTemplateTagPrefixParsing(t *testing.T) {
-	// Bare "template" with no colon: not a template field. Should fall through
-	// to the normal tag pipeline, which has no provider named "template" and
-	// must therefore return an error rather than silently producing "template".
-	type NoColon struct {
-		X string `faker:"template"`
-	}
-	var n NoColon
-	if err := FakeData(&n); err == nil && n.X == "template" {
-		t.Fatalf("bare 'template' tag was incorrectly treated as a template field, got X=%q", n.X)
-	}
-
-	// "templated" shares a prefix with "template" but is a distinct (unknown) tag.
-	// It must not be routed through the template engine.
-	type FalsePrefix struct {
-		X string `faker:"templated"`
-	}
-	var f FalsePrefix
-	if err := FakeData(&f); err == nil && f.X == "templated" {
-		t.Fatalf("'templated' tag was incorrectly treated as a template field, got X=%q", f.X)
-	}
-}
-
-func TestEvaluateTemplateFields(t *testing.T) {
 	cases := []struct {
-		name        string
-		setup       func() (reflect.Type, reflect.Value, []int)
-		expectErr   bool
-		expectCheck func() error
+		name string
+		tag  string
+		fake func() error
 	}{
 		{
-			name: "email-lower",
-			setup: func() (reflect.Type, reflect.Value, []int) {
-				type T struct {
-					Name  string
-					Email string `faker:"template:{{.Name | lower}}@example.com"`
+			name: "bare_template_without_colon",
+			tag:  "template",
+			fake: func() error {
+				var v struct {
+					X string `faker:"template"`
 				}
-				var inst T
-				inst.Name = "John"
-				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{1}
-			},
-			expectErr: false,
-			expectCheck: func() error {
-				return nil
+				return FakeData(&v)
 			},
 		},
 		{
-			name: "multiple",
-			setup: func() (reflect.Type, reflect.Value, []int) {
-				type T struct {
-					Name     string
-					Email    string `faker:"template:{{.Name | lower}}@example.com"`
-					Username string `faker:"template:{{.Name | lower}}"`
+			name: "templated_shares_a_prefix",
+			tag:  "templated",
+			fake: func() error {
+				var v struct {
+					X string `faker:"templated"`
 				}
-				var inst T
-				inst.Name = "John"
-				// template fields are at indices 1 and 2
-				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{1, 2}
+				return FakeData(&v)
 			},
-			expectErr: false,
-		},
-		{
-			name: "chained",
-			setup: func() (reflect.Type, reflect.Value, []int) {
-				type T struct {
-					Name  string
-					Slug  string `faker:"template:{{.Name | slug}}"`
-					Email string `faker:"template:{{.Slug}}@example.com"`
-				}
-				var inst T
-				inst.Name = "John"
-				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{1, 2}
-			},
-			expectErr: false,
-		},
-		{
-			name: "slug",
-			setup: func() (reflect.Type, reflect.Value, []int) {
-				type T struct {
-					Name string
-					Slug string `faker:"template:{{.Name | slug}}"`
-				}
-				var inst T
-				inst.Name = "Hello, World!"
-				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{1}
-			},
-			expectErr: false,
-		},
-		{
-			name: "nested",
-			setup: func() (reflect.Type, reflect.Value, []int) {
-				type Addr struct{ City string }
-				type T struct {
-					Addr Addr
-					Desc string `faker:"template:City is {{.Addr.City}}"`
-				}
-				var inst T
-				inst.Addr.City = "Jakarta"
-				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{1}
-			},
-			expectErr: false,
-		},
-		{
-			name: "order",
-			setup: func() (reflect.Type, reflect.Value, []int) {
-				type T struct {
-					Email string `faker:"template:{{.Name | lower}}@example.com"`
-					Name  string
-				}
-				var inst T
-				inst.Name = "John"
-				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{0}
-			},
-			expectErr: false,
-		},
-		{
-			name: "nonstring-error",
-			setup: func() (reflect.Type, reflect.Value, []int) {
-				type T struct {
-					Name string
-					Age  int `faker:"template:{{.Name}}"`
-				}
-				var inst T
-				inst.Name = "John"
-				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{1}
-			},
-			expectErr: true,
-		},
-		{
-			name: "circular-reference",
-			setup: func() (reflect.Type, reflect.Value, []int) {
-				type T struct {
-					A string `faker:"template:{{.B}}-x"`
-					B string `faker:"template:{{.A}}-y"`
-				}
-				var inst T
-				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{0, 1}
-			},
-			expectErr: true,
-		},
-		{
-			name: "self-reference",
-			setup: func() (reflect.Type, reflect.Value, []int) {
-				type T struct {
-					A string `faker:"template:{{.A}}-x"`
-				}
-				var inst T
-				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{0}
-			},
-			expectErr: true,
-		},
-		{
-			name: "forward-reference",
-			setup: func() (reflect.Type, reflect.Value, []int) {
-				type T struct {
-					A string `faker:"template:{{.B}}"`
-					B string `faker:"template:hello"`
-				}
-				var inst T
-				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{0, 1}
-			},
-			expectErr: true,
-		},
-		{
-			name: "missing-field-reference",
-			setup: func() (reflect.Type, reflect.Value, []int) {
-				type T struct {
-					Name string
-					Bad  string `faker:"template:{{.DoesNotExist}}"`
-				}
-				var inst T
-				inst.Name = "John"
-				return reflect.TypeOf(inst), reflect.ValueOf(&inst).Elem(), []int{1}
-			},
-			expectErr: true,
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			rt, rv, fields := c.setup()
-			err := EvaluateTemplateFields(rt, rv, fields, "faker")
-			if c.expectErr {
-				if err == nil {
-					t.Fatalf("expected error for case %s", c.name)
-				}
-				return
+			err := c.fake()
+			if err == nil {
+				t.Fatalf("expected %q to be rejected as an unknown tag, got nil error", c.tag)
 			}
+			want := fmt.Sprintf(fakerErrors.ErrTagNotSupported, c.tag)
+			if err.Error() != want {
+				t.Fatalf("error = %q, want %q", err.Error(), want)
+			}
+		})
+	}
+}
+
+// TestTemplateFieldRefs covers dependency extraction. A regular expression over
+// the template source cannot get these right: it matches literal text, reports
+// sub-selectors as fields, and cannot see that range/with rebind the dot.
+func TestTemplateFieldRefs(t *testing.T) {
+	cases := []struct {
+		name string
+		tpl  string
+		want []string
+	}{
+		{"simple", "{{.User}}", []string{"User"}},
+		{"literal_text_is_not_a_reference", "{{.User}}@Example.Com", []string{"User"}},
+		{"sub_selector_reports_the_root_only", "{{.Addr.City}}", []string{"Addr"}},
+		{"pipeline", "{{.A | lower}}", []string{"A"}},
+		{"printf_args", `{{printf "%s-%s" .A .B}}`, []string{"A", "B"}},
+		{"if_else_do_not_rebind_dot", "{{if .Flag}}{{.A}}{{else}}{{.B}}{{end}}", []string{"Flag", "A", "B"}},
+		{"range_body_rebinds_dot", "{{range .Items}}{{.Name}}{{end}}", []string{"Items"}},
+		{"with_body_rebinds_dot", "{{with .Addr}}{{.City}}{{else}}{{.Fallback}}{{end}}", []string{"Addr", "Fallback"}},
+		{"variable_declaration", "{{$x := .A}}{{$x}}", []string{"A"}},
+		{"plain_text", "no fields here .NotAField", nil},
+		{"bare_dot", "{{.}}", nil},
+		{"deduplicated", "{{.A}}-{{.A}}", []string{"A"}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tpl, err := template.New("t").Funcs(templateHelpers).Parse(c.tpl)
 			if err != nil {
-				t.Fatalf("unexpected error for case %s: %v", c.name, err)
+				t.Fatalf("parse: %v", err)
 			}
-			// basic sanity checks per-case
-			switch c.name {
-			case "email-lower":
-				if rv.Field(1).String() != "john@example.com" {
-					t.Fatalf("email-lower mismatch: %q", rv.Field(1).String())
-				}
-			case "slug":
-				if rv.Field(1).String() != "hello-world" {
-					t.Fatalf("slug mismatch: %q", rv.Field(1).String())
-				}
-			case "nested":
-				if rv.Field(1).String() != "City is Jakarta" {
-					t.Fatalf("nested mismatch: %q", rv.Field(1).String())
-				}
-			case "order":
-				if rv.Field(0).String() != "john@example.com" {
-					t.Fatalf("order mismatch: %q", rv.Field(0).String())
+			got := templateFieldRefs(tpl.Tree)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("templateFieldRefs(%q) = %v, want %v", c.tpl, got, c.want)
+			}
+		})
+	}
+}
+
+func TestTopoSortTemplateFields(t *testing.T) {
+	// build turns a declaration order plus a name -> dependency-names map into the
+	// []templateField the sorter expects.
+	build := func(order []string, deps map[string][]string) []templateField {
+		pos := make(map[string]int, len(order))
+		fields := make([]templateField, len(order))
+		for i, n := range order {
+			pos[n] = i
+			fields[i] = templateField{index: i, name: n}
+		}
+		for _, n := range order {
+			for _, d := range deps[n] {
+				fields[pos[n]].deps = append(fields[pos[n]].deps, pos[d])
+			}
+		}
+		return fields
+	}
+
+	t.Run("linear_chain_declared_in_reverse", func(t *testing.T) {
+		fields := build([]string{"C", "B", "A"}, map[string][]string{
+			"C": {"B"},
+			"B": {"A"},
+		})
+		order, err := topoSortTemplateFields(fields)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var names []string
+		for _, p := range order {
+			names = append(names, fields[p].name)
+		}
+		if want := []string{"A", "B", "C"}; !reflect.DeepEqual(names, want) {
+			t.Fatalf("order = %v, want %v", names, want)
+		}
+	})
+
+	t.Run("diamond", func(t *testing.T) {
+		fields := build([]string{"D", "B", "C", "A"}, map[string][]string{
+			"D": {"B", "C"},
+			"B": {"A"},
+			"C": {"A"},
+		})
+		order, err := topoSortTemplateFields(fields)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(order) != 4 {
+			t.Fatalf("order = %v, want 4 entries", order)
+		}
+		seen := make(map[string]int)
+		for i, p := range order {
+			seen[fields[p].name] = i
+		}
+		for _, pair := range [][2]string{{"A", "B"}, {"A", "C"}, {"B", "D"}, {"C", "D"}} {
+			if seen[pair[0]] > seen[pair[1]] {
+				t.Errorf("%s must be evaluated before %s, got %v", pair[0], pair[1], seen)
+			}
+		}
+	})
+
+	t.Run("independent_chains_are_deterministic", func(t *testing.T) {
+		fields := build([]string{"A", "B", "C", "D"}, map[string][]string{
+			"B": {"A"},
+			"D": {"C"},
+		})
+		first, err := topoSortTemplateFields(fields)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for range 20 {
+			again, err := topoSortTemplateFields(fields)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(first, again) {
+				t.Fatalf("order is not deterministic: %v then %v", first, again)
+			}
+		}
+	})
+
+	cycles := []struct {
+		name    string
+		order   []string
+		deps    map[string][]string
+		members []string
+	}{
+		{"self", []string{"A"}, map[string][]string{"A": {"A"}}, []string{"A"}},
+		{"two_node", []string{"A", "B"}, map[string][]string{"A": {"B"}, "B": {"A"}}, []string{"A", "B"}},
+		{"three_node", []string{"A", "B", "C"}, map[string][]string{"A": {"B"}, "B": {"C"}, "C": {"A"}}, []string{"A", "B", "C"}},
+	}
+	for _, c := range cycles {
+		t.Run("cycle_"+c.name, func(t *testing.T) {
+			_, err := topoSortTemplateFields(build(c.order, c.deps))
+			if err == nil {
+				t.Fatal("expected a cycle error")
+			}
+			for _, m := range c.members {
+				if !strings.Contains(err.Error(), m) {
+					t.Errorf("error %q does not name cycle member %q", err, m)
 				}
 			}
 		})
+	}
+}
+
+// TestTemplateTagWithUnexportedField is the repro from the review of
+// go-faker/faker#83: building the template context used to call
+// reflect.Value.Interface on every field, which panics for unexported ones.
+func TestTemplateTagWithUnexportedField(t *testing.T) {
+	t.Run("unexported_field_is_ignored", func(t *testing.T) {
+		type PrivateField struct {
+			password  string
+			FirstName string `faker:"first_name"`
+			Slug      string `faker:"template:{{.FirstName | slug}}"`
+		}
+
+		var u PrivateField
+		if err := FakeData(&u); err != nil {
+			t.Fatal(err)
+		}
+		if u.FirstName == "" {
+			t.Fatal("expected non-empty FirstName")
+		}
+		if u.Slug == "" {
+			t.Fatal("expected non-empty Slug")
+		}
+		if want := slugify(u.FirstName); u.Slug != want {
+			t.Fatalf("Slug = %q, want %q", u.Slug, want)
+		}
+		if u.password != "" {
+			t.Fatalf("unexported field was written: %q", u.password)
+		}
+	})
+
+	t.Run("referencing_an_unexported_field_errors", func(t *testing.T) {
+		type PrivateRef struct {
+			password string
+			Bad      string `faker:"template:{{.password}}"`
+		}
+
+		var u PrivateRef
+		err := FakeData(&u)
+		if err == nil {
+			t.Fatal("expected an error when a template reads an unexported field")
+		}
+		if !strings.Contains(err.Error(), "password") {
+			t.Fatalf("error %q does not mention the offending field", err)
+		}
+		_ = u.password
+	})
+}
+
+// TestTemplateTagDependencyOrder covers references to template fields declared
+// later in the struct, which used to be rejected outright.
+func TestTemplateTagDependencyOrder(t *testing.T) {
+	t.Run("forward_reference", func(t *testing.T) {
+		type U struct {
+			FirstName string `faker:"first_name"`
+			Domain    string `faker:"domain_name"`
+			Email     string `faker:"template:{{.Username}}@{{.Domain}}"`
+			Username  string `faker:"template:{{.FirstName | lower}}"`
+		}
+
+		var u U
+		if err := FakeData(&u); err != nil {
+			t.Fatal(err)
+		}
+		if want := strings.ToLower(u.FirstName); u.Username != want {
+			t.Fatalf("Username = %q, want %q", u.Username, want)
+		}
+		if want := u.Username + "@" + u.Domain; u.Email != want {
+			t.Fatalf("Email = %q, want %q", u.Email, want)
+		}
+	})
+
+	t.Run("three_level_chain_declared_in_reverse", func(t *testing.T) {
+		type U struct {
+			C    string `faker:"template:{{.B}}-c"`
+			B    string `faker:"template:{{.A}}-b"`
+			A    string `faker:"template:{{.Seed | lower}}"`
+			Seed string `faker:"first_name"`
+		}
+
+		var u U
+		if err := FakeData(&u); err != nil {
+			t.Fatal(err)
+		}
+		wantA := strings.ToLower(u.Seed)
+		if u.A != wantA || u.B != wantA+"-b" || u.C != wantA+"-b-c" {
+			t.Fatalf("chain resolved incorrectly: A=%q B=%q C=%q (seed %q)", u.A, u.B, u.C, u.Seed)
+		}
+	})
+}
+
+func TestTemplateTagCycleDetection(t *testing.T) {
+	t.Run("self", func(t *testing.T) {
+		var u struct {
+			A string `faker:"template:{{.A}}-x"`
+		}
+		err := FakeData(&u)
+		if err == nil || !strings.Contains(err.Error(), "cycle") {
+			t.Fatalf("expected a cycle error, got %v", err)
+		}
+	})
+
+	t.Run("two_node", func(t *testing.T) {
+		var u struct {
+			A string `faker:"template:{{.B}}-x"`
+			B string `faker:"template:{{.A}}-y"`
+		}
+		err := FakeData(&u)
+		if err == nil {
+			t.Fatal("expected a cycle error")
+		}
+		for _, name := range []string{"A", "B"} {
+			if !strings.Contains(err.Error(), name) {
+				t.Errorf("error %q does not name cycle member %q", err, name)
+			}
+		}
+	})
+
+	t.Run("three_node", func(t *testing.T) {
+		var u struct {
+			A string `faker:"template:{{.B}}"`
+			B string `faker:"template:{{.C}}"`
+			C string `faker:"template:{{.A}}"`
+		}
+		if err := FakeData(&u); err == nil {
+			t.Fatal("expected a cycle error")
+		}
+	})
+}
+
+func TestTemplateTagNonStringField(t *testing.T) {
+	type U struct {
+		Name string `faker:"first_name"`
+		Age  int    `faker:"template:{{.Name}}"`
+		Ok   string `faker:"template:{{.Name | upper}}"`
+	}
+
+	var u U
+	err := FakeData(&u)
+	if err == nil {
+		t.Fatal("expected an error for a template tag on an int field")
+	}
+	if !strings.Contains(err.Error(), "Age") {
+		t.Fatalf("error %q does not name the offending field", err)
+	}
+	// Validation must happen before anything is evaluated, so the sibling template
+	// field must not have been written.
+	if u.Ok != "" {
+		t.Fatalf("sibling template field was evaluated despite the error: %q", u.Ok)
+	}
+}
+
+func TestTemplateTagPointerAndNamedStringField(t *testing.T) {
+	type Slug string
+	type U struct {
+		Name    string  `faker:"first_name"`
+		Slug    Slug    `faker:"template:{{.Name | slug}}"`
+		Pointer *string `faker:"template:{{.Name | upper}}"`
+	}
+
+	var u U
+	if err := FakeData(&u); err != nil {
+		t.Fatal(err)
+	}
+	if want := Slug(slugify(u.Name)); u.Slug != want {
+		t.Fatalf("Slug = %q, want %q", u.Slug, want)
+	}
+	if u.Pointer == nil {
+		t.Fatal("expected Pointer to be allocated")
+	}
+	if want := strings.ToUpper(u.Name); *u.Pointer != want {
+		t.Fatalf("*Pointer = %q, want %q", *u.Pointer, want)
+	}
+}
+
+func TestTemplateTagWithUnique(t *testing.T) {
+	type U struct {
+		Name string `faker:"first_name"`
+		Slug string `faker:"template:{{.Name | lower}},unique"`
+	}
+
+	var u U
+	err := FakeData(&u)
+	if err == nil {
+		t.Fatal("expected unique+template to be rejected")
+	}
+	if want := fmt.Sprintf(fakerErrors.ErrTemplateWithUnique, "Slug"); err.Error() != want {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+	// The old behavior silently dropped the tag and filled the field with a random
+	// string; make sure that has not come back.
+	if u.Slug != "" {
+		t.Fatalf("Slug was written despite the error: %q", u.Slug)
+	}
+}
+
+func TestTemplateTagWithKeep(t *testing.T) {
+	type U struct {
+		Name string `faker:"first_name"`
+		Slug string `faker:"template:{{.Name | lower}},keep"`
+	}
+
+	t.Run("non_zero_value_is_kept", func(t *testing.T) {
+		u := U{Slug: "preset"}
+		if err := FakeData(&u); err != nil {
+			t.Fatal(err)
+		}
+		if u.Slug != "preset" {
+			t.Fatalf("Slug = %q, want the preset value to be kept", u.Slug)
+		}
+	})
+
+	t.Run("zero_value_is_templated", func(t *testing.T) {
+		var u U
+		if err := FakeData(&u); err != nil {
+			t.Fatal(err)
+		}
+		if want := strings.ToLower(u.Name); u.Slug != want {
+			t.Fatalf("Slug = %q, want %q", u.Slug, want)
+		}
+	})
+}
+
+func TestTemplateTagWithCommaInBody(t *testing.T) {
+	type U struct {
+		First string `faker:"first_name"`
+		Last  string `faker:"last_name"`
+		Full  string `faker:"template:{{.Last}}, {{.First}}"`
+	}
+
+	var u U
+	if err := FakeData(&u); err != nil {
+		t.Fatal(err)
+	}
+	if want := u.Last + ", " + u.First; u.Full != want {
+		t.Fatalf("Full = %q, want %q", u.Full, want)
+	}
+}
+
+func TestTemplateTagWithOptionOverrides(t *testing.T) {
+	type U struct {
+		Name    string `faker:"first_name"`
+		Slug    string `faker:"template:{{.Name | lower}}"`
+		Derived string `faker:"template:{{.Slug}}-x"`
+	}
+
+	t.Run("ignored_field_wins_and_dependents_see_it", func(t *testing.T) {
+		var u U
+		if err := FakeData(&u, options.WithFieldsToIgnore("Slug")); err != nil {
+			t.Fatal(err)
+		}
+		if u.Slug != "" {
+			t.Fatalf("Slug = %q, want it left at the zero value", u.Slug)
+		}
+		if u.Derived != "-x" {
+			t.Fatalf("Derived = %q, want %q", u.Derived, "-x")
+		}
+	})
+
+	t.Run("field_provider_wins_and_dependents_see_it", func(t *testing.T) {
+		var u U
+		err := FakeData(&u, options.WithCustomFieldProvider("Slug", func() (any, error) {
+			return "provided", nil
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if u.Slug != "provided" {
+			t.Fatalf("Slug = %q, want %q", u.Slug, "provided")
+		}
+		if u.Derived != "provided-x" {
+			t.Fatalf("Derived = %q, want %q", u.Derived, "provided-x")
+		}
+	})
+
+	t.Run("only_zero_fields_keeps_a_preset_template_field", func(t *testing.T) {
+		u := U{Slug: "preset"}
+		if err := FakeData(&u, options.WithOnlyZeroFields()); err != nil {
+			t.Fatal(err)
+		}
+		if u.Slug != "preset" {
+			t.Fatalf("Slug = %q, want the preset value", u.Slug)
+		}
+		if u.Derived != "preset-x" {
+			t.Fatalf("Derived = %q, want %q", u.Derived, "preset-x")
+		}
+	})
+}
+
+func TestTemplateTagInNestedStruct(t *testing.T) {
+	type Inner struct {
+		Name string `faker:"first_name"`
+		Slug string `faker:"template:{{.Name | slug}}"`
+	}
+
+	t.Run("nested_struct_and_pointer", func(t *testing.T) {
+		type Outer struct {
+			A Inner
+			B *Inner
+		}
+		var o Outer
+		if err := FakeData(&o); err != nil {
+			t.Fatal(err)
+		}
+		if o.A.Slug != slugify(o.A.Name) {
+			t.Errorf("A: Slug = %q, want %q", o.A.Slug, slugify(o.A.Name))
+		}
+		if o.B == nil {
+			t.Fatal("expected B to be allocated")
+		}
+		if o.B.Slug != slugify(o.B.Name) {
+			t.Errorf("B: Slug = %q, want %q", o.B.Slug, slugify(o.B.Name))
+		}
+	})
+
+	t.Run("slice_elements_are_independent", func(t *testing.T) {
+		type Outer struct {
+			Items []Inner `faker:"slice_len=5"`
+		}
+		var o Outer
+		if err := FakeData(&o); err != nil {
+			t.Fatal(err)
+		}
+		if len(o.Items) != 5 {
+			t.Fatalf("len(Items) = %d, want 5", len(o.Items))
+		}
+		for i, it := range o.Items {
+			if it.Slug != slugify(it.Name) {
+				t.Errorf("Items[%d]: Slug = %q, want %q derived from its own Name %q",
+					i, it.Slug, slugify(it.Name), it.Name)
+			}
+		}
+	})
+}
+
+func TestTemplateTagWithEmbeddedStruct(t *testing.T) {
+	type Address struct {
+		City string `faker:"word"`
+	}
+	type U struct {
+		Address
+		Promoted string `faker:"template:{{.City}}"`
+		Explicit string `faker:"template:{{.Address.City}}"`
+	}
+
+	var u U
+	if err := FakeData(&u); err != nil {
+		t.Fatal(err)
+	}
+	if u.City == "" {
+		t.Fatal("expected the embedded City to be generated")
+	}
+	if u.Promoted != u.City {
+		t.Errorf("Promoted = %q, want the promoted City %q", u.Promoted, u.City)
+	}
+	if u.Explicit != u.City {
+		t.Errorf("Explicit = %q, want %q", u.Explicit, u.City)
+	}
+}
+
+func TestTemplateTagErrors(t *testing.T) {
+	cases := []struct {
+		name  string
+		field string
+		fake  func() error
+	}{
+		{
+			name:  "missing_field",
+			field: "Bad",
+			fake: func() error {
+				var v struct {
+					Name string `faker:"first_name"`
+					Bad  string `faker:"template:{{.DoesNotExist}}"`
+				}
+				return FakeData(&v)
+			},
+		},
+		{
+			name:  "invalid_syntax",
+			field: "Bad",
+			fake: func() error {
+				var v struct {
+					Bad string `faker:"template:{{.Unclosed"`
+				}
+				return FakeData(&v)
+			},
+		},
+		{
+			name:  "empty_body",
+			field: "Bad",
+			fake: func() error {
+				var v struct {
+					Bad string `faker:"template:"`
+				}
+				return FakeData(&v)
+			},
+		},
+		{
+			name:  "unknown_helper",
+			field: "Bad",
+			fake: func() error {
+				var v struct {
+					Name string `faker:"first_name"`
+					Bad  string `faker:"template:{{.Name | nosuchhelper}}"`
+				}
+				return FakeData(&v)
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.fake()
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), c.field) {
+				t.Fatalf("error %q does not name the offending field %q", err, c.field)
+			}
+		})
+	}
+}
+
+func TestTemplateTagWithTagName(t *testing.T) {
+	type U struct {
+		Name string `fake:"first_name"`
+		Slug string `fake:"template:{{.Name | lower}}"`
+	}
+
+	var u U
+	if err := FakeData(&u, options.WithTagName("fake")); err != nil {
+		t.Fatal(err)
+	}
+	if u.Name == "" {
+		t.Fatal("expected Name to be generated")
+	}
+	if want := strings.ToLower(u.Name); u.Slug != want {
+		t.Fatalf("Slug = %q, want %q", u.Slug, want)
+	}
+}
+
+func TestTemplateTagNonStringValueInTemplate(t *testing.T) {
+	type U struct {
+		Age   int    `faker:"boundary_start=30, boundary_end=31"`
+		Label string `faker:"template:age-{{.Age}}"`
+		Slug  string `faker:"template:{{.Age | slug}}"`
+	}
+
+	var u U
+	if err := FakeData(&u); err != nil {
+		t.Fatal(err)
+	}
+	if want := fmt.Sprintf("age-%d", u.Age); u.Label != want {
+		t.Fatalf("Label = %q, want %q", u.Label, want)
+	}
+	if want := fmt.Sprintf("%d", u.Age); u.Slug != want {
+		t.Fatalf("Slug = %q, want %q", u.Slug, want)
+	}
+}
+
+func TestTemplateTagWithMaxFieldDepth(t *testing.T) {
+	type U struct {
+		Name string `faker:"first_name"`
+		Slug string `faker:"template:{{.Name | lower}}"`
+	}
+
+	var u U
+	if err := FakeData(&u, options.WithMaxFieldDepthOption(0)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if u.Slug != "" {
+		t.Fatalf("Slug = %q, want empty at depth 0", u.Slug)
+	}
+}
+
+func TestTemplateTagConcurrent(t *testing.T) {
+	type U struct {
+		First    string `faker:"first_name"`
+		Last     string `faker:"last_name"`
+		Domain   string `faker:"domain_name"`
+		Email    string `faker:"template:{{.Username}}@{{.Domain}}"`
+		Username string `faker:"template:{{.First | lower}}.{{.Last | lower}}"`
+	}
+
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 10 {
+				var u U
+				if err := FakeData(&u); err != nil {
+					t.Error(err)
+					return
+				}
+				want := strings.ToLower(u.First) + "." + strings.ToLower(u.Last)
+				if u.Username != want {
+					t.Errorf("Username = %q, want %q", u.Username, want)
+					return
+				}
+				if u.Email != u.Username+"@"+u.Domain {
+					t.Errorf("Email = %q, want %q", u.Email, u.Username+"@"+u.Domain)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestSlugify(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Hello, World!", "hello-world"},
+		{"  --Hello--  ", "hello"},
+		{"already-a-slug", "already-a-slug"},
+		{"José", "josé"},
+		{"Иван", "иван"},
+		{"李雷", "李雷"},
+		{"a1b2", "a1b2"},
+		{"!!!", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := slugify(c.in); got != c.want {
+			t.Errorf("slugify(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// abc is the sample value shared by the TestTemplateString cases.
+const abc = "abc"
+
+// testStringer exercises the fmt.Stringer branch of templateString.
+type testStringer struct{ s string }
+
+func (t testStringer) String() string { return t.s }
+
+func TestTemplateString(t *testing.T) {
+	type named string
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"nil", nil, ""},
+		{"string", abc, abc},
+		{"named_string", named(abc), abc},
+		{"int", 42, "42"},
+		{"float", 1.5, "1.5"},
+		{"bool", true, "true"},
+		{"stringer", testStringer{abc}, abc},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := templateString(c.in); got != c.want {
+				t.Fatalf("templateString(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestTemplateHelpers(t *testing.T) {
+	type named string
+	type U struct {
+		S string `faker:"-"`
+		N named  `faker:"-"`
+		I int    `faker:"-"`
+
+		Lower string `faker:"template:{{.S | lower}}"`
+		Upper string `faker:"template:{{.S | upper}}"`
+		Trim  string `faker:"template:{{.S | trim}}"`
+		Named string `faker:"template:{{.N | upper}}"`
+		Num   string `faker:"template:{{.I | lower}}"`
+	}
+
+	u := U{S: "  MiXeD  ", N: named("ab"), I: 7}
+	if err := FakeData(&u); err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range []struct{ name, got, want string }{
+		{"lower", u.Lower, "  mixed  "},
+		{"upper", u.Upper, "  MIXED  "},
+		{"trim", u.Trim, "MiXeD"},
+		{"upper on a named string", u.Named, "AB"},
+		{"lower on an int", u.Num, "7"},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s = %q, want %q", c.name, c.got, c.want)
+		}
+	}
+}
+
+func BenchmarkFakerDataTemplateTag(b *testing.B) {
+	type U struct {
+		First    string `faker:"first_name"`
+		Last     string `faker:"last_name"`
+		Domain   string `faker:"domain_name"`
+		Username string `faker:"template:{{.First | lower}}.{{.Last | lower}}"`
+		Slug     string `faker:"template:{{.First | slug}}-{{.Last | slug}}"`
+		Email    string `faker:"template:{{.Username}}@{{.Domain}}"`
+	}
+	for b.Loop() {
+		var u U
+		if err := FakeData(&u); err != nil {
+			b.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
Add `template: ` struct tag which renders a Go text/template using values generated for other fields. Templates are evaluated in a **second pass** after non-template fields are generated, so templates can reference provider-generated values and other template fields (**chaining supported**). Small helper functions are also provided.

**Rules**
- Only for string type fields

**Why**
Derived fields (username, email, slug, etc.) are quite common.

**Example**
```go
type UserProfile struct {
    FirstName string `faker:"first_name"`
    LastName  string `faker:"last_name"`
    Domain    string `faker:"domain_name"`

    // templates using helpers
    Username string `faker:"template:{{.FirstName | lower}}.{{.LastName | lower}}"`
    Slug     string `faker:"template:{{.FirstName | slug}}-{{.LastName | slug}}"`
    Email    string `faker:"template:{{.Username}}@{{.Domain}}"`
}

func main() {
    var u UserProfile
    if err := faker.FakeData(&u); err != nil {
        panic(err)
    }
    fmt.Printf("%+v\n", u)
}

//Result
UserProfile{
  FirstName: "John",
  LastName: "Doe",
  Domain: "example.org",
  Username: "john.doe", // lower helper applied
  Slug: "john-doe", // slug helper applied (lower + dashes)
  Email: "john.doe@example.org"// username + domain via template
}
```