### PR TITLE
feat: upgrade to Go 1.26 and modernize with go fix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,15 +6,17 @@ on:
   pull_request:
     branches: [ "main" ]
 
+# Use the exact toolchain that setup-go installs. Without this, GOTOOLCHAIN=auto
+# would silently download the version required by go.mod and ignore the matrix.
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   run-tests:
     strategy:
       matrix:
         version: [
-          "~1.21",
-          "~1.22",
-          "~1.23",
-          "~1.24"
+          "~1.26"
         ]
     runs-on: ubuntu-latest
     steps:
@@ -38,7 +40,7 @@ jobs:
     strategy:
       matrix:
         version: [
-          "~1.24"
+          "~1.26"
         ]
     steps:
       - uses: actions/checkout@v4

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -40,6 +40,9 @@ linters:
       - std-error-handling
     rules:
       - linters:
+          - goconst
+        path: lorem.go
+      - linters:
           - misspell
         path: person.go
       - linters:

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Support For :
 Unfortunately this library has some limitation
 
 - It does not support private fields. Make sure your structs fields you intend to generate fake data for are public, it would otherwise trigger a panic. You can however omit fields using a tag skip `faker:"-"` on your private fields.
-- It does not support the `interface{}` data type. How could we generate anything without knowing its data type?
-- It does not support the `map[interface{}]interface{}`, `map[any_type]interface{}` & `map[interface{}]any_type` data types. Once again, we cannot generate values for an unknown data type.
+- It does not support the `any` (empty interface) data type. How could we generate anything without knowing its data type?
+- It does not support the `map[any]any`, `map[T]any` & `map[any]T` data types (where `T` is any concrete type). Once again, we cannot generate values for an unknown data type.
 - Some extra custom types can be supported IF AND ONLY IF extended with [AddProvider()](https://github.com/go-faker/faker/blob/7473ac7d8d0440d24addac302c73e13c08895764/faker.go#L303) please see [example](example_custom_faker_test.go#L46)
 - The `oneof` tag currently only supports `string`, the `int` types, and both `float32` & `float64`. Further support is coming soon (i.e. hex numbers, etc). See [example](example_with_tags_test.go#L53) for usage.
 

--- a/address.go
+++ b/address.go
@@ -42,10 +42,10 @@ func GetAddress() Addresser {
 
 // Addresser is logical layer for Address
 type Addresser interface {
-	Latitude(v reflect.Value) (interface{}, error)
-	Longitude(v reflect.Value) (interface{}, error)
-	RealWorld(v reflect.Value) (interface{}, error)
-	CountryInfo(v reflect.Value) (interface{}, error)
+	Latitude(v reflect.Value) (any, error)
+	Longitude(v reflect.Value) (any, error)
+	RealWorld(v reflect.Value) (any, error)
+	CountryInfo(v reflect.Value) (any, error)
 }
 
 // Address struct
@@ -56,7 +56,7 @@ func (i Address) latitude() float32 {
 }
 
 // Latitude sets latitude of the address
-func (i Address) Latitude(v reflect.Value) (interface{}, error) {
+func (i Address) Latitude(v reflect.Value) (any, error) {
 	kind := v.Kind()
 	val := i.latitude()
 	if kind == reflect.Float32 {
@@ -70,7 +70,7 @@ func (i Address) longitude() float32 {
 }
 
 // Longitude sets longitude of the address
-func (i Address) Longitude(v reflect.Value) (interface{}, error) {
+func (i Address) Longitude(v reflect.Value) (any, error) {
 	kind := v.Kind()
 	val := i.longitude()
 	if kind == reflect.Float32 {
@@ -87,18 +87,18 @@ func (i Address) countryInfo() CountryInfo {
 	return countries[rand.Intn(len(countries))]
 }
 
-func (i Address) CountryInfo(_ reflect.Value) (interface{}, error) {
+func (i Address) CountryInfo(_ reflect.Value) (any, error) {
 	return i.countryInfo(), nil
 }
 
 // RealWorld sets real world address
-func (i Address) RealWorld(_ reflect.Value) (interface{}, error) {
+func (i Address) RealWorld(_ reflect.Value) (any, error) {
 	return i.realWorld(), nil
 }
 
 // Longitude get fake longitude randomly
 func Longitude(opts ...options.OptionFunc) float64 {
-	return singleFakeData(LONGITUDE, func() interface{} {
+	return singleFakeData(LONGITUDE, func() any {
 		address := Address{}
 		return float64(address.longitude())
 	}, opts...).(float64)
@@ -106,7 +106,7 @@ func Longitude(opts ...options.OptionFunc) float64 {
 
 // Latitude get fake latitude randomly
 func Latitude(opts ...options.OptionFunc) float64 {
-	return singleFakeData(LATITUDE, func() interface{} {
+	return singleFakeData(LATITUDE, func() any {
 		address := Address{}
 		return float64(address.latitude())
 	}, opts...).(float64)
@@ -127,7 +127,7 @@ type RealAddress struct {
 
 // GetRealAddress get real world address randomly
 func GetRealAddress(opts ...options.OptionFunc) RealAddress {
-	return singleFakeData(RealAddressTag, func() interface{} {
+	return singleFakeData(RealAddressTag, func() any {
 		address := Address{}
 		return address.realWorld()
 	}, opts...).(RealAddress)
@@ -142,7 +142,7 @@ type CountryInfo struct {
 }
 
 func GetCountryInfo(opts ...options.OptionFunc) CountryInfo {
-	return singleFakeData(CountryInfoTag, func() interface{} {
+	return singleFakeData(CountryInfoTag, func() any {
 		address := Address{}
 		return address.countryInfo()
 	}, opts...).(CountryInfo)

--- a/blood.go
+++ b/blood.go
@@ -19,9 +19,9 @@ func GetBlood(opts ...options.OptionFunc) Blooder {
 }
 
 type Blooder interface {
-	BloodType(v reflect.Value) (interface{}, error)
-	BloodRHFactor(v reflect.Value) (interface{}, error)
-	BloodGroup(v reflect.Value) (interface{}, error)
+	BloodType(v reflect.Value) (any, error)
+	BloodRHFactor(v reflect.Value) (any, error)
+	BloodGroup(v reflect.Value) (any, error)
 }
 
 // Internet struct
@@ -33,7 +33,7 @@ func (b Blood) bloodType() string {
 	return randomElementFromSliceString(bloodTypes)
 }
 
-func (b Blood) BloodType(v reflect.Value) (interface{}, error) {
+func (b Blood) BloodType(v reflect.Value) (any, error) {
 	return b.bloodType(), nil
 }
 
@@ -41,7 +41,7 @@ func (b Blood) bloodRhFactor() string {
 	return randomElementFromSliceString(bloodRhFactors)
 }
 
-func (b Blood) BloodRHFactor(v reflect.Value) (interface{}, error) {
+func (b Blood) BloodRHFactor(v reflect.Value) (any, error) {
 	return b.bloodRhFactor(), nil
 }
 
@@ -49,6 +49,6 @@ func (b Blood) bloodGroup() string {
 	return fmt.Sprintf("%s%s", b.bloodType(), b.bloodRhFactor())
 }
 
-func (b Blood) BloodGroup(v reflect.Value) (interface{}, error) {
+func (b Blood) BloodGroup(v reflect.Value) (any, error) {
 	return b.bloodGroup(), nil
 }

--- a/datetime.go
+++ b/datetime.go
@@ -606,17 +606,17 @@ const (
 
 // A DateTimer contains random Time generators, returning time string in certain particular format
 type DateTimer interface {
-	UnixTime(v reflect.Value) (interface{}, error)
-	Date(v reflect.Value) (interface{}, error)
-	Time(v reflect.Value) (interface{}, error)
-	MonthName(v reflect.Value) (interface{}, error)
-	Year(v reflect.Value) (interface{}, error)
-	DayOfWeek(v reflect.Value) (interface{}, error)
-	DayOfMonth(v reflect.Value) (interface{}, error)
-	Timestamp(v reflect.Value) (interface{}, error)
-	Century(v reflect.Value) (interface{}, error)
-	TimeZone(v reflect.Value) (interface{}, error)
-	TimePeriod(v reflect.Value) (interface{}, error)
+	UnixTime(v reflect.Value) (any, error)
+	Date(v reflect.Value) (any, error)
+	Time(v reflect.Value) (any, error)
+	MonthName(v reflect.Value) (any, error)
+	Year(v reflect.Value) (any, error)
+	DayOfWeek(v reflect.Value) (any, error)
+	DayOfMonth(v reflect.Value) (any, error)
+	Timestamp(v reflect.Value) (any, error)
+	Century(v reflect.Value) (any, error)
+	TimeZone(v reflect.Value) (any, error)
+	TimePeriod(v reflect.Value) (any, error)
 }
 
 // GetDateTimer returns a new DateTimer interface of DateTime
@@ -634,7 +634,7 @@ func (d DateTime) unixtime() int64 {
 }
 
 // UnixTime get unix time
-func (d DateTime) UnixTime(v reflect.Value) (interface{}, error) {
+func (d DateTime) UnixTime(v reflect.Value) (any, error) {
 	kind := v.Kind()
 	var val int64
 	if kind == reflect.Int64 {
@@ -648,7 +648,7 @@ func (d DateTime) UnixTime(v reflect.Value) (interface{}, error) {
 
 // UnixTime get unix time randomly
 func UnixTime(opts ...options.OptionFunc) int64 {
-	return singleFakeData(UnixTimeTag, func() interface{} {
+	return singleFakeData(UnixTimeTag, func() any {
 		datetime := DateTime{}
 		return datetime.unixtime()
 	}, opts...).(int64)
@@ -659,13 +659,13 @@ func (d DateTime) date() string {
 }
 
 // Date formats DateTime using example BaseDateFormat const
-func (d DateTime) Date(v reflect.Value) (interface{}, error) {
+func (d DateTime) Date(v reflect.Value) (any, error) {
 	return d.date(), nil
 }
 
 // Date get fake date in string randomly
 func Date(opts ...options.OptionFunc) string {
-	return singleFakeData(DATE, func() interface{} {
+	return singleFakeData(DATE, func() any {
 		datetime := DateTime{}
 		return datetime.date()
 	}, opts...).(string)
@@ -676,13 +676,13 @@ func (d DateTime) time() string {
 }
 
 // Time formats DateTime using example Time const
-func (d DateTime) Time(v reflect.Value) (interface{}, error) {
+func (d DateTime) Time(v reflect.Value) (any, error) {
 	return d.time(), nil
 }
 
 // TimeString get time randomly in string format
 func TimeString(opts ...options.OptionFunc) string {
-	return singleFakeData(TIME, func() interface{} {
+	return singleFakeData(TIME, func() any {
 		datetime := DateTime{}
 		return datetime.time()
 	}, opts...).(string)
@@ -693,13 +693,13 @@ func (d DateTime) monthName() string {
 }
 
 // MonthName formats DateTime using example Month const
-func (d DateTime) MonthName(v reflect.Value) (interface{}, error) {
+func (d DateTime) MonthName(v reflect.Value) (any, error) {
 	return d.monthName(), nil
 }
 
 // MonthName get month name randomly in string format
 func MonthName(opts ...options.OptionFunc) string {
-	return singleFakeData(MonthNameTag, func() interface{} {
+	return singleFakeData(MonthNameTag, func() any {
 		datetime := DateTime{}
 		return datetime.monthName()
 	}, opts...).(string)
@@ -710,13 +710,13 @@ func (d DateTime) year() string {
 }
 
 // Year formats DateTime using example Year const
-func (d DateTime) Year(v reflect.Value) (interface{}, error) {
+func (d DateTime) Year(v reflect.Value) (any, error) {
 	return d.year(), nil
 }
 
 // YearString get year randomly in string format
 func YearString(opts ...options.OptionFunc) string {
-	return singleFakeData(YEAR, func() interface{} {
+	return singleFakeData(YEAR, func() any {
 		datetime := DateTime{}
 		return datetime.year()
 	}, opts...).(string)
@@ -727,13 +727,13 @@ func (d DateTime) dayOfWeek() string {
 }
 
 // DayOfWeek formats DateTime using example Day const
-func (d DateTime) DayOfWeek(v reflect.Value) (interface{}, error) {
+func (d DateTime) DayOfWeek(v reflect.Value) (any, error) {
 	return d.dayOfWeek(), nil
 }
 
 // DayOfWeek get day of week randomly in string format
 func DayOfWeek(opts ...options.OptionFunc) string {
-	return singleFakeData(DayOfWeekTag, func() interface{} {
+	return singleFakeData(DayOfWeekTag, func() any {
 		datetime := DateTime{}
 		return datetime.dayOfWeek()
 	}, opts...).(string)
@@ -744,13 +744,13 @@ func (d DateTime) dayOfMonth() string {
 }
 
 // DayOfMonth formats DateTime using example DayOfMonth const
-func (d DateTime) DayOfMonth(v reflect.Value) (interface{}, error) {
+func (d DateTime) DayOfMonth(v reflect.Value) (any, error) {
 	return d.dayOfMonth(), nil
 }
 
 // DayOfMonth get month randomly in string format
 func DayOfMonth(opts ...options.OptionFunc) string {
-	return singleFakeData(DayOfMonthTag, func() interface{} {
+	return singleFakeData(DayOfMonthTag, func() any {
 		datetime := DateTime{}
 		return datetime.dayOfMonth()
 	}, opts...).(string)
@@ -761,13 +761,13 @@ func (d DateTime) timestamp() string {
 }
 
 // Timestamp formats DateTime using example Timestamp const
-func (d DateTime) Timestamp(v reflect.Value) (interface{}, error) {
+func (d DateTime) Timestamp(v reflect.Value) (any, error) {
 	return d.timestamp(), nil
 }
 
 // Timestamp get timestamp randomly in string format: 2006-01-02 15:04:05
 func Timestamp(opts ...options.OptionFunc) string {
-	return singleFakeData(TIMESTAMP, func() interface{} {
+	return singleFakeData(TIMESTAMP, func() any {
 		datetime := DateTime{}
 		return datetime.timestamp()
 	}, opts...).(string)
@@ -778,13 +778,13 @@ func (d DateTime) century() string {
 }
 
 // Century returns a random century
-func (d DateTime) Century(v reflect.Value) (interface{}, error) {
+func (d DateTime) Century(v reflect.Value) (any, error) {
 	return d.century(), nil
 }
 
 // Century get century randomly in string
 func Century(opts ...options.OptionFunc) string {
-	return singleFakeData(CENTURY, func() interface{} {
+	return singleFakeData(CENTURY, func() any {
 		datetime := DateTime{}
 		return datetime.century()
 	}, opts...).(string)
@@ -795,13 +795,13 @@ func (d DateTime) timezone() string {
 }
 
 // TimeZone returns a random timezone
-func (d DateTime) TimeZone(v reflect.Value) (interface{}, error) {
+func (d DateTime) TimeZone(v reflect.Value) (any, error) {
 	return d.timezone(), nil
 }
 
 // Timezone get timezone randomly in string
 func Timezone(opts ...options.OptionFunc) string {
-	return singleFakeData(TIMEZONE, func() interface{} {
+	return singleFakeData(TIMEZONE, func() any {
 		datetime := DateTime{}
 		return datetime.timezone()
 	}, opts...).(string)
@@ -812,13 +812,13 @@ func (d DateTime) period() string {
 }
 
 // TimePeriod formats DateTime using example TimePeriod const
-func (d DateTime) TimePeriod(v reflect.Value) (interface{}, error) {
+func (d DateTime) TimePeriod(v reflect.Value) (any, error) {
 	return d.period(), nil
 }
 
 // Timeperiod get timeperiod randomly in string (AM/PM)
 func Timeperiod(opts ...options.OptionFunc) string {
-	return singleFakeData(TimePeriodTag, func() interface{} {
+	return singleFakeData(TimePeriodTag, func() any {
 		datetime := DateTime{}
 		return datetime.period()
 	}, opts...).(string)

--- a/example_custom_faker_test.go
+++ b/example_custom_faker_test.go
@@ -26,14 +26,14 @@ type Sample struct {
 
 // CustomGenerator ...
 func CustomGenerator() {
-	_ = faker.AddProvider("customIdFaker", func(v reflect.Value) (interface{}, error) {
+	_ = faker.AddProvider("customIdFaker", func(v reflect.Value) (any, error) {
 		return int64(43), nil
 	})
-	_ = faker.AddProvider("danger", func(v reflect.Value) (interface{}, error) {
+	_ = faker.AddProvider("danger", func(v reflect.Value) (any, error) {
 		return "danger-ranger", nil
 	})
 
-	_ = faker.AddProvider("gondoruwo", func(v reflect.Value) (interface{}, error) {
+	_ = faker.AddProvider("gondoruwo", func(v reflect.Value) (any, error) {
 		obj := Gondoruwo{
 			Name:       "Power",
 			Locatadata: 324,
@@ -41,7 +41,7 @@ func CustomGenerator() {
 		return obj, nil
 	})
 
-	_ = faker.AddProvider("customUUID", func(v reflect.Value) (interface{}, error) {
+	_ = faker.AddProvider("customUUID", func(v reflect.Value) (any, error) {
 		s := CustomUUID{
 			0, 8, 7, 2, 3,
 		}

--- a/example_custom_struct_test.go
+++ b/example_custom_struct_test.go
@@ -20,9 +20,9 @@ func Example_structTypeProviders() {
 		UUID faker.UUID
 	}
 
-	_ = faker.FakeData(&s, options.WithStructTypeProviders(RedefinedTime{}, func() (interface{}, error) {
+	_ = faker.FakeData(&s, options.WithStructTypeProviders(RedefinedTime{}, func() (any, error) {
 		return time.Now(), nil
-	}), options.WithStructTypeProviders(big.Rat{}, func() (interface{}, error) {
+	}), options.WithStructTypeProviders(big.Rat{}, func() (any, error) {
 		return *big.NewRat(rand.Int63(), rand.Int63n(1<<63-1)+1), nil
 	}))
 	fmt.Printf("time: %v\n", time.Time(*s.T))

--- a/example_with_tags_unique_test.go
+++ b/example_with_tags_unique_test.go
@@ -12,7 +12,7 @@ type SomeStructWithUnique struct {
 }
 
 func Example_withTagsAndUnique() {
-	for i := 0; i < 5; i++ { // Generate 5 structs having a unique word
+	for range 5 { // Generate 5 structs having a unique word
 		a := SomeStructWithUnique{}
 		err := faker.FakeData(&a)
 		if err != nil {

--- a/faker.go
+++ b/faker.go
@@ -124,7 +124,7 @@ func (m *mapperTagCustom) Load(key string) (interfaces.TaggedFunction, bool) {
 	if ok {
 		return tagFunc, ok
 	}
-	tagPureFunc, ok := mappedTagFunc.(func(v reflect.Value) (interface{}, error))
+	tagPureFunc, ok := mappedTagFunc.(func(v reflect.Value) (any, error))
 	if ok {
 		return tagPureFunc, ok
 	}
@@ -310,11 +310,11 @@ func initOption(opt ...options.OptionFunc) *options.Options {
 
 // FakeData is the main function. Will generate a fake data based on your struct.  You can use this for automation testing, or anything that need automated data.
 // You don't need to Create your own data for your testing.
-func FakeData(a interface{}, opt ...options.OptionFunc) error {
+func FakeData(a any, opt ...options.OptionFunc) error {
 	opts := initOption(opt...)
 	reflectType := reflect.TypeOf(a)
 
-	if reflectType.Kind() != reflect.Ptr {
+	if reflectType.Kind() != reflect.Pointer {
 		return errors.New(fakerErrors.ErrValueNotPtr)
 	}
 
@@ -401,7 +401,7 @@ func RemoveProvider(tag string) error {
 	return nil
 }
 
-func getFakedValue(item interface{}, opts *options.Options) (reflect.Value, error) {
+func getFakedValue(item any, opts *options.Options) (reflect.Value, error) {
 	t := reflect.TypeOf(item)
 	if t == nil {
 		if opts.IgnoreInterface {
@@ -418,7 +418,7 @@ func getFakedValue(item interface{}, opts *options.Options) (reflect.Value, erro
 	}()
 	k := t.Kind()
 	switch k {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		v := reflect.New(t.Elem())
 		var val reflect.Value
 		var err error
@@ -454,7 +454,7 @@ func getFakedValue(item interface{}, opts *options.Options) (reflect.Value, erro
 		}
 		v := reflect.MakeSlice(t, length, length)
 		innerOpts := opts.Nested()
-		for i := 0; i < length; i++ {
+		for i := range length {
 			val, err := getFakedValue(v.Index(i).Interface(), &innerOpts)
 			if err != nil {
 				return reflect.Value{}, err
@@ -527,7 +527,7 @@ func getFakedValue(item interface{}, opts *options.Options) (reflect.Value, erro
 		}
 		v := reflect.MakeMap(t)
 		innerOpts := opts.Nested()
-		for i := 0; i < length; i++ {
+		for range length {
 			keyInstance := reflect.New(t.Key()).Elem().Interface()
 			key, err := getFakedValue(keyInstance, &innerOpts)
 			if err != nil {
@@ -558,7 +558,7 @@ func getFakedValue(item interface{}, opts *options.Options) (reflect.Value, erro
 
 }
 
-func getFakedValueForStruct(item interface{}, t reflect.Type, opts *options.Options) (reflect.Value, error) {
+func getFakedValueForStruct(item any, t reflect.Type, opts *options.Options) (reflect.Value, error) {
 	if structTypeProvider, f := opts.StructTypeProviders[t]; f {
 		ft, err := structTypeProvider()
 		return reflect.ValueOf(ft), err
@@ -641,7 +641,7 @@ func getFakedValueForStruct(item interface{}, t reflect.Type, opts *options.Opti
 			}
 			value := v.Field(i).Interface()
 			uniqueVal, _ := uniqueValues.Load(tags.fieldType)
-			uniqueValArr, _ := uniqueVal.([]interface{})
+			uniqueValArr, _ := uniqueVal.([]any)
 			if slice.ContainsValue(uniqueValArr, value) { // Retry if unique value already found
 				i--
 				retry++
@@ -724,12 +724,12 @@ type structTag struct {
 }
 
 func setDataWithTag(v reflect.Value, tag string, opt options.Options) error {
-	if v.Kind() != reflect.Ptr {
+	if v.Kind() != reflect.Pointer {
 		return errors.New(fakerErrors.ErrValueNotPtr)
 	}
 	v = reflect.Indirect(v)
 	switch v.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if _, exist := mapperTag.Load(tag); !exist {
 			newv := reflect.New(v.Type().Elem())
 			if err := setDataWithTag(newv, tag, opt); err != nil {
@@ -806,7 +806,7 @@ func userDefinedMap(v reflect.Value, tag string, opt options.Options) error {
 	}
 	innerOpt := opt.Nested()
 	definedMap := reflect.MakeMap(v.Type())
-	for i := 0; i < length; i++ {
+	for range length {
 		key, err := getValueWithTag(v.Type().Key(), tag, innerOpt)
 		if err != nil {
 			return err
@@ -821,7 +821,7 @@ func userDefinedMap(v reflect.Value, tag string, opt options.Options) error {
 	return nil
 }
 
-func getValueWithTag(t reflect.Type, tag string, opt options.Options) (interface{}, error) {
+func getValueWithTag(t reflect.Type, tag string, opt options.Options) (any, error) {
 	switch t.Kind() {
 	case reflect.Int, reflect.Int32, reflect.Int64, reflect.Int8, reflect.Int16, reflect.Uint, reflect.Uint8,
 		reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64:
@@ -841,7 +841,7 @@ func getValueWithTag(t reflect.Type, tag string, opt options.Options) (interface
 	}
 }
 
-func getNumberWithBoundary(t reflect.Type, boundary interfaces.RandomIntegerBoundary) (interface{}, error) {
+func getNumberWithBoundary(t reflect.Type, boundary interfaces.RandomIntegerBoundary) (any, error) {
 	switch t.Kind() {
 	case reflect.Uint:
 		return uint(randomIntegerWithBoundary(boundary)), nil
@@ -868,7 +868,7 @@ func getNumberWithBoundary(t reflect.Type, boundary interfaces.RandomIntegerBoun
 	}
 }
 
-func getValueWithNoTag(t reflect.Type, opt options.Options) (interface{}, error) {
+func getValueWithNoTag(t reflect.Type, opt options.Options) (any, error) {
 	switch t.Kind() {
 	case reflect.Int, reflect.Int32, reflect.Int64, reflect.Int8, reflect.Int16, reflect.Uint, reflect.Uint8,
 		reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64:
@@ -947,7 +947,7 @@ func userDefinedArray(v reflect.Value, tag string, opt options.Options) error {
 }
 
 func userDefinedString(v reflect.Value, tag string, opt options.Options) error {
-	var res interface{}
+	var res any
 	var err error
 
 	if tagFunc, ok := mapperTag.Load(tag); ok {
@@ -970,7 +970,7 @@ func userDefinedString(v reflect.Value, tag string, opt options.Options) error {
 }
 
 func userDefinedNumber(v reflect.Value, tag string) error {
-	var res interface{}
+	var res any
 	var err error
 
 	if tagFunc, ok := mapperTag.Load(tag); ok {
@@ -1014,7 +1014,7 @@ func extractSliceLengthFromTag(tag string, opt options.Options) (int, error) {
 	return randomSliceAndMapSize(opt), nil //Returns random slice length if the sliceLength tag isn't set
 }
 
-func extractStringFromTag(tag string, opts options.Options) (interface{}, error) {
+func extractStringFromTag(tag string, opts options.Options) (any, error) {
 	var err error
 	strlen := opts.RandomStringLength
 	strlng := opts.StringLanguage
@@ -1075,7 +1075,7 @@ func extractLangFromTag(tag string) (*interfaces.LangRuneBoundary, error) {
 	}
 }
 
-func extractNumberFromTag(tag string, t reflect.Type) (interface{}, error) {
+func extractNumberFromTag(tag string, t reflect.Type) (any, error) {
 	hasOneOf := strings.Contains(tag, ONEOF)
 	hasBoundaryStart := strings.Contains(tag, BoundaryStart)
 	hasBoundaryEnd := strings.Contains(tag, BoundaryEnd)
@@ -1348,10 +1348,7 @@ func randomSliceAndMapSize(opt options.Options) int {
 		maxSize = opt.RandomNestedMaxSliceSize
 		minSize = opt.RandomNestedMinSliceSize
 	}
-	r := maxSize - minSize
-	if r < 1 {
-		r = 1
-	}
+	r := max(maxSize-minSize, 1)
 	return minSize + rand.Intn(r)
 }
 
@@ -1413,11 +1410,11 @@ func RandomInt(parameters ...int) (p []int, err error) {
 	return p, err
 }
 
-func generateUnique(dataType string, fn func() interface{}) (interface{}, error) {
-	for i := 0; i < maxRetry; i++ {
+func generateUnique(dataType string, fn func() any) (any, error) {
+	for range maxRetry {
 		value := fn()
 		uniqueVal, _ := uniqueValues.Load(dataType)
-		uniqueValArr, _ := uniqueVal.([]interface{})
+		uniqueValArr, _ := uniqueVal.([]any)
 		if !slice.ContainsValue(uniqueValArr, value) { // Retry if unique value already found
 			uniqueValues.Store(dataType, append(uniqueValArr, value))
 			return value, nil
@@ -1426,7 +1423,7 @@ func generateUnique(dataType string, fn func() interface{}) (interface{}, error)
 	return reflect.Value{}, fmt.Errorf(fakerErrors.ErrUniqueFailure, dataType)
 }
 
-func singleFakeData(dataType string, fn func() interface{}, opts ...options.OptionFunc) interface{} {
+func singleFakeData(dataType string, fn func() any, opts ...options.OptionFunc) any {
 	ops := initOption(opts...)
 	if ops.GenerateUniqueValues {
 		v, err := generateUnique(dataType, fn)

--- a/faker_test.go
+++ b/faker_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	mathrand "math/rand"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -399,11 +400,11 @@ func TestFakerData(t *testing.T) {
 
 func TestCustomFakerOnUnsupportedMapStringInterface(t *testing.T) {
 	type Sample struct {
-		Map map[string]interface{} `faker:"custom"`
+		Map map[string]any `faker:"custom"`
 	}
 
-	err := AddProvider("custom", func(v reflect.Value) (interface{}, error) {
-		return map[string]interface{}{"foo": "bar"}, nil
+	err := AddProvider("custom", func(v reflect.Value) (any, error) {
+		return map[string]any{"foo": "bar"}, nil
 	})
 	if err != nil {
 		t.Error("Expected NoError, but Got Err", err)
@@ -427,7 +428,7 @@ func TestCustomFakerOnUnsupportedMapStringInterface(t *testing.T) {
 
 func TestUnsuportedMapStringInterface(t *testing.T) {
 	type Sample struct {
-		Map map[string]interface{}
+		Map map[string]any
 	}
 	var sample = new(Sample)
 	if err := FakeData(sample, options.WithRandomMapAndSliceMinSize(1)); err == nil {
@@ -586,7 +587,7 @@ func TestSetNilIfLenIsZero(t *testing.T) {
 }
 
 func TestSetIgnoreInterface(t *testing.T) {
-	var someInterface interface{}
+	var someInterface any
 	if err := FakeData(&someInterface, options.WithIgnoreInterface(false)); err == nil {
 		t.Error("Fake data generation didn't fail on interface{}")
 	}
@@ -609,7 +610,7 @@ func TestSetIgnoreInterface(t *testing.T) {
 func TestBoundaryAndLen(t *testing.T) {
 	iterate := 10
 	someStruct := SomeStructWithLen{}
-	for i := 0; i < iterate; i++ {
+	for range iterate {
 		if err := FakeData(&someStruct); err != nil {
 			t.Error(err)
 		}
@@ -1206,7 +1207,7 @@ func TestExtend(t *testing.T) {
 			ID string `faker:"test"`
 		}{}
 
-		err := AddProvider("test", func(v reflect.Value) (interface{}, error) {
+		err := AddProvider("test", func(v reflect.Value) (any, error) {
 			return "test", nil
 		})
 
@@ -1227,7 +1228,7 @@ func TestExtend(t *testing.T) {
 
 	t.Run("test-struct", func(t *testing.T) {
 		a := &Student{}
-		err := AddProvider("custom-school", func(v reflect.Value) (interface{}, error) {
+		err := AddProvider("custom-school", func(v reflect.Value) (any, error) {
 
 			sch := School{
 				Location: "North Kindom",
@@ -1258,7 +1259,7 @@ func TestExtend(t *testing.T) {
 
 	t.Run("test-with-custom-slice-type", func(t *testing.T) {
 		a := CustomThatUsesSlice{}
-		err := AddProvider("custom-type-over-slice", func(v reflect.Value) (interface{}, error) {
+		err := AddProvider("custom-type-over-slice", func(v reflect.Value) (any, error) {
 			return CustomTypeOverSlice{0, 1, 2, 3, 4}, nil
 		})
 
@@ -1285,7 +1286,7 @@ func TestExtend(t *testing.T) {
 	t.Run("test with type alias for int", func(t *testing.T) {
 		a := Sample{}
 		sliceLen := 10
-		err := AddProvider("myint", func(v reflect.Value) (interface{}, error) {
+		err := AddProvider("myint", func(v reflect.Value) (any, error) {
 			r1 := mathrand.New(NewSafeSource(mathrand.NewSource(time.Now().UnixNano())))
 			r := make([]MyInt, sliceLen)
 			for i := range r {
@@ -1315,7 +1316,7 @@ func TestExtend(t *testing.T) {
 func TestTagAlreadyExists(t *testing.T) {
 	// This test is to ensure that existing tag cannot be rewritten
 
-	err := AddProvider(EmailTag, func(v reflect.Value) (interface{}, error) {
+	err := AddProvider(EmailTag, func(v reflect.Value) (any, error) {
 		return nil, nil
 	})
 
@@ -1325,7 +1326,7 @@ func TestTagAlreadyExists(t *testing.T) {
 }
 
 func TestRemoveProvider(t *testing.T) {
-	err := AddProvider("new_test_tag", func(v reflect.Value) (interface{}, error) {
+	err := AddProvider("new_test_tag", func(v reflect.Value) (any, error) {
 		return "test", nil
 	})
 	if err != nil {
@@ -1357,7 +1358,7 @@ func TestTagWithPointer(t *testing.T) {
 		School     *School  `faker:"school"`
 	}
 	// With custom provider
-	err := AddProvider("school", func(v reflect.Value) (interface{}, error) {
+	err := AddProvider("school", func(v reflect.Value) (any, error) {
 		return &School{Location: "Jakarta"}, nil
 	})
 	if err != nil {
@@ -1457,7 +1458,7 @@ func TestItThrowsAnErrorWhenKeepIsUsedOnIncomparableType(t *testing.T) {
 	withSlice := TypeStructWithSlice{}
 	withArray := TypeStructWithArray{}
 
-	for _, item := range []interface{}{withArray, withStruct, withSlice} {
+	for _, item := range []any{withArray, withStruct, withSlice} {
 		err := FakeData(&item)
 		if err == nil {
 			t.Errorf("expected error, but got nil")
@@ -1467,7 +1468,7 @@ func TestItThrowsAnErrorWhenKeepIsUsedOnIncomparableType(t *testing.T) {
 
 func TestItThrowsAnErrorWhenPointerToInterfaceIsUsed(t *testing.T) {
 	type PtrToInterface struct {
-		Interface *interface{}
+		Interface *any
 	}
 
 	interfacePtr := PtrToInterface{}
@@ -1497,7 +1498,7 @@ func TestUnique(t *testing.T) {
 		IntVal    int    `faker:"unique"`
 	}
 
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		val := UniqueStruct{}
 		err := FakeData(&val)
 		if err != nil {
@@ -1505,16 +1506,14 @@ func TestUnique(t *testing.T) {
 		}
 	}
 
-	found := []interface{}{}
+	found := []any{}
 	uniqueVal, _ := uniqueValues.Load("word")
-	uniqueValArr := uniqueVal.([]interface{})
+	uniqueValArr := uniqueVal.([]any)
 	for _, v := range uniqueValArr {
-		for _, f := range found {
-			if f == v {
-				t.Errorf("expected unique values, found \"%s\" at least twice", v)
-				ResetUnique()
-				return
-			}
+		if slices.Contains(found, v) {
+			t.Errorf("expected unique values, found \"%s\" at least twice", v)
+			ResetUnique()
+			return
 		}
 		found = append(found, v)
 	}
@@ -1551,7 +1550,7 @@ func TestUniqueReset(t *testing.T) {
 		StringVal string `faker:"word,unique"`
 	}
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		val := String{}
 		err := FakeData(&val)
 		if err != nil {
@@ -1561,7 +1560,7 @@ func TestUniqueReset(t *testing.T) {
 
 	ResetUnique()
 	var getSize = func(m *sync.Map) (count int) {
-		m.Range(func(_, _ interface{}) bool {
+		m.Range(func(_, _ any) bool {
 			count++
 			return true
 		})
@@ -1581,7 +1580,7 @@ func TestUniqueFailure(t *testing.T) {
 
 	hasError := false
 	length := len(wordList) + 1
-	for i := 0; i < length; i++ {
+	for range length {
 		val := String{}
 		err := FakeData(&val)
 		if err != nil {
@@ -2379,7 +2378,7 @@ func TestRandomMapSliceSize(t *testing.T) {
 		Map   map[string]int
 	}
 	expect := 5
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		s := SliceMap{}
 		err := FakeData(&s, options.WithRandomMapAndSliceMaxSize(uint(expect)))
 		if err != nil {
@@ -2486,9 +2485,9 @@ func TestWithTagName(t *testing.T) {
 
 // assertAllStructFieldsNonZero asserts that the given struct s has all fields set to a non-zero value.
 // s must be a struct or a pointer to a struct, the function panics otherwise.
-func assertAllStructFieldsNonZero(s interface{}) error {
+func assertAllStructFieldsNonZero(s any) error {
 	v := reflect.ValueOf(s)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 
@@ -2530,10 +2529,10 @@ func TestWithFieldProvider(t *testing.T) {
 	const heightVal = int64(123)
 	const nameVal = "some string"
 	if err := FakeData(&a,
-		options.WithCustomFieldProvider("Height", func() (interface{}, error) {
+		options.WithCustomFieldProvider("Height", func() (any, error) {
 			return heightVal, nil
 		}),
-		options.WithCustomFieldProvider("Name", func() (interface{}, error) {
+		options.WithCustomFieldProvider("Name", func() (any, error) {
 			return nameVal, nil
 		}),
 	); err != nil {
@@ -2548,7 +2547,7 @@ func TestWithFieldProvider(t *testing.T) {
 	}
 
 	// when provider fails
-	if err := FakeData(&a, options.WithCustomFieldProvider("Height", func() (interface{}, error) {
+	if err := FakeData(&a, options.WithCustomFieldProvider("Height", func() (any, error) {
 		return nil, fmt.Errorf("test")
 	})); err == nil {
 		t.Errorf("expected an error, but got nil")
@@ -2630,7 +2629,7 @@ func TestFakeDate_ConcurrentSafe(_ *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1000)
 	fmt.Println("Running for loop…")
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		go func(i int) {
 			defer wg.Done()
 			_ = i
@@ -2661,17 +2660,17 @@ func TestNonEmptyInterface(t *testing.T) {
 type InterfaceStruct struct {
 	A string
 	B map[string]any
-	C map[string]interface{}
+	C map[string]any
 	D Interface
-	E interface{}
-	F map[interface{}]any
+	E any
+	F map[any]any
 	G map[any]any
-	H map[any]interface{}
-	I []interface{}
-	J [2]interface{}
-	K [][]interface{}
-	L [][2]interface{}
-	M [3][2]interface{}
+	H map[any]any
+	I []any
+	J [2]any
+	K [][]any
+	L [][2]any
+	M [3][2]any
 	N map[any][]any
 	O []int
 }
@@ -2714,7 +2713,7 @@ func TestRandomString(t *testing.T) {
 		opt   = options.DefaultOption()
 	)
 
-	for i := 0; i < count; i++ {
+	for range count {
 		str, err := randomString(20, *opt)
 		if err != nil {
 			t.Error("Expected NoError, but Got Err:", err)
@@ -2735,9 +2734,9 @@ func TestStructTypeProvidersToBeFilled(t *testing.T) {
 		RP *big.Rat
 		R  big.Rat
 	}
-	if err := FakeData(&s, options.WithStructTypeProviders(RedefinedTime{}, func() (interface{}, error) {
+	if err := FakeData(&s, options.WithStructTypeProviders(RedefinedTime{}, func() (any, error) {
 		return time.Now(), nil
-	}), options.WithStructTypeProviders(big.Rat{}, func() (interface{}, error) {
+	}), options.WithStructTypeProviders(big.Rat{}, func() (any, error) {
 		return *big.NewRat(rand.Int63(), rand.Int63n(1<<63-1)+1), nil
 	})); err != nil {
 		t.Errorf("%+v", err)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/go-faker/faker/v4
 
-go 1.26.5
+go 1.26.0
 
 require golang.org/x/text v0.29.0

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/go-faker/faker/v4
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.26.5
 
 require golang.org/x/text v0.29.0

--- a/internet.go
+++ b/internet.go
@@ -46,15 +46,15 @@ func GetNetworker(opts ...options.OptionFunc) Networker {
 
 // Networker is logical layer for Internet
 type Networker interface {
-	Email(v reflect.Value) (interface{}, error)
-	MacAddress(v reflect.Value) (interface{}, error)
-	DomainName(v reflect.Value) (interface{}, error)
-	URL(v reflect.Value) (interface{}, error)
-	UserName(v reflect.Value) (interface{}, error)
-	IPv4(v reflect.Value) (interface{}, error)
-	IPv6(v reflect.Value) (interface{}, error)
-	Password(v reflect.Value) (interface{}, error)
-	Jwt(v reflect.Value) (interface{}, error)
+	Email(v reflect.Value) (any, error)
+	MacAddress(v reflect.Value) (any, error)
+	DomainName(v reflect.Value) (any, error)
+	URL(v reflect.Value) (any, error)
+	UserName(v reflect.Value) (any, error)
+	IPv4(v reflect.Value) (any, error)
+	IPv6(v reflect.Value) (any, error)
+	Password(v reflect.Value) (any, error)
+	Jwt(v reflect.Value) (any, error)
 }
 
 // Internet struct
@@ -84,13 +84,13 @@ func (internet Internet) email() (string, error) {
 }
 
 // Email generates random email id
-func (internet Internet) Email(v reflect.Value) (interface{}, error) {
+func (internet Internet) Email(v reflect.Value) (any, error) {
 	return internet.email()
 }
 
 // Email get email randomly in string
 func Email(opts ...options.OptionFunc) string {
-	return singleFakeData(EmailTag, func() interface{} {
+	return singleFakeData(EmailTag, func() any {
 		opt := options.BuildOptions(opts)
 		i := Internet{fakerOption: *opt}
 		r, err := i.email()
@@ -103,20 +103,20 @@ func Email(opts ...options.OptionFunc) string {
 
 func (internet Internet) macAddress() string {
 	ip := make([]byte, 6)
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		ip[i] = byte(rand.Intn(256))
 	}
 	return net.HardwareAddr(ip).String()
 }
 
 // MacAddress generates random MacAddress
-func (internet Internet) MacAddress(v reflect.Value) (interface{}, error) {
+func (internet Internet) MacAddress(v reflect.Value) (any, error) {
 	return internet.macAddress(), nil
 }
 
 // MacAddress get mac address randomly in string
 func MacAddress(opts ...options.OptionFunc) string {
-	return singleFakeData(MacAddressTag, func() interface{} {
+	return singleFakeData(MacAddressTag, func() any {
 		opt := options.BuildOptions(opts)
 		i := Internet{fakerOption: *opt}
 		return i.macAddress()
@@ -132,13 +132,13 @@ func (internet Internet) domainName() (string, error) {
 }
 
 // DomainName generates random domain name
-func (internet Internet) DomainName(v reflect.Value) (interface{}, error) {
+func (internet Internet) DomainName(v reflect.Value) (any, error) {
 	return internet.domainName()
 }
 
 // DomainName get email domain name in string
 func DomainName(opts ...options.OptionFunc) string {
-	return singleFakeData(DomainNameTag, func() interface{} {
+	return singleFakeData(DomainNameTag, func() any {
 		opt := options.BuildOptions(opts)
 		i := Internet{fakerOption: *opt}
 		d, err := i.domainName()
@@ -167,13 +167,13 @@ func (internet Internet) url() (string, error) {
 }
 
 // URL generates random URL standardized in urlFormats const
-func (internet Internet) URL(v reflect.Value) (interface{}, error) {
+func (internet Internet) URL(v reflect.Value) (any, error) {
 	return internet.url()
 }
 
 // URL get Url randomly in string
 func URL(opts ...options.OptionFunc) string {
-	return singleFakeData(URLTag, func() interface{} {
+	return singleFakeData(URLTag, func() any {
 		opt := options.BuildOptions(opts)
 		i := Internet{fakerOption: *opt}
 		u, err := i.url()
@@ -189,13 +189,13 @@ func (internet Internet) username() (string, error) {
 }
 
 // UserName generates random username
-func (internet Internet) UserName(v reflect.Value) (interface{}, error) {
+func (internet Internet) UserName(v reflect.Value) (any, error) {
 	return internet.username()
 }
 
 // Username get username randomly in string
 func Username(opts ...options.OptionFunc) string {
-	return singleFakeData(UserNameTag, func() interface{} {
+	return singleFakeData(UserNameTag, func() any {
 		opt := options.BuildOptions(opts)
 		i := Internet{fakerOption: *opt}
 		u, err := i.username()
@@ -209,20 +209,20 @@ func Username(opts ...options.OptionFunc) string {
 func (internet Internet) ipv4() string {
 	size := 4
 	ip := make([]byte, size)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		ip[i] = byte(rand.Intn(256))
 	}
 	return net.IP(ip).To4().String()
 }
 
 // IPv4 generates random IPv4 address
-func (internet Internet) IPv4(v reflect.Value) (interface{}, error) {
+func (internet Internet) IPv4(v reflect.Value) (any, error) {
 	return internet.ipv4(), nil
 }
 
 // IPv4 get IPv4 randomly in string
 func IPv4(opts ...options.OptionFunc) string {
-	return singleFakeData(IPV4Tag, func() interface{} {
+	return singleFakeData(IPV4Tag, func() any {
 		opt := options.BuildOptions(opts)
 		i := Internet{fakerOption: *opt}
 		return i.ipv4()
@@ -232,20 +232,20 @@ func IPv4(opts ...options.OptionFunc) string {
 func (internet Internet) ipv6() string {
 	size := 16
 	ip := make([]byte, size)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		ip[i] = byte(rand.Intn(256))
 	}
 	return net.IP(ip).To16().String()
 }
 
 // IPv6 generates random IPv6 address
-func (internet Internet) IPv6(v reflect.Value) (interface{}, error) {
+func (internet Internet) IPv6(v reflect.Value) (any, error) {
 	return internet.ipv6(), nil
 }
 
 // IPv6 get IPv6 randomly in string
 func IPv6(opts ...options.OptionFunc) string {
-	return singleFakeData(IPV6Tag, func() interface{} {
+	return singleFakeData(IPV6Tag, func() any {
 		opt := options.BuildOptions(opts)
 		i := Internet{fakerOption: *opt}
 		return i.ipv6()
@@ -257,13 +257,13 @@ func (internet Internet) password() (string, error) {
 }
 
 // Password returns a hashed password
-func (internet Internet) Password(v reflect.Value) (interface{}, error) {
+func (internet Internet) Password(v reflect.Value) (any, error) {
 	return internet.password()
 }
 
 // Password get password randomly in string
 func Password(opts ...options.OptionFunc) string {
-	return singleFakeData(PASSWORD, func() interface{} {
+	return singleFakeData(PASSWORD, func() any {
 		opt := options.BuildOptions(opts)
 		i := Internet{fakerOption: *opt}
 		p, err := i.password()
@@ -284,13 +284,13 @@ func (internet Internet) jwt() (string, error) {
 }
 
 // Jwt returns a jwt-like random string in xxxx.yyyy.zzzz style
-func (internet Internet) Jwt(v reflect.Value) (interface{}, error) {
+func (internet Internet) Jwt(v reflect.Value) (any, error) {
 	return internet.jwt()
 }
 
 // Jwt get jwt-like string
 func Jwt(opts ...options.OptionFunc) string {
-	return singleFakeData(JWT, func() interface{} {
+	return singleFakeData(JWT, func() any {
 		opt := options.BuildOptions(opts)
 		i := Internet{fakerOption: *opt}
 		p, err := i.jwt()

--- a/lorem.go
+++ b/lorem.go
@@ -52,9 +52,9 @@ var wordList = []string{
 
 // DataFaker generates randomized Words, Sentences and Paragraphs
 type DataFaker interface {
-	Word(v reflect.Value) (interface{}, error)
-	Sentence(v reflect.Value) (interface{}, error)
-	Paragraph(v reflect.Value) (interface{}, error)
+	Word(v reflect.Value) (any, error)
+	Sentence(v reflect.Value) (any, error)
+	Paragraph(v reflect.Value) (any, error)
 }
 
 // GetLorem returns a new DataFaker interface of Lorem struct
@@ -72,14 +72,14 @@ func (l Lorem) word() string {
 }
 
 // Word returns a word from the wordList const
-func (l Lorem) Word(v reflect.Value) (interface{}, error) {
+func (l Lorem) Word(v reflect.Value) (any, error) {
 	return l.word(), nil
 }
 
 // Word get a word randomly in string
 func Word(opts ...options.OptionFunc) string {
 	i := Lorem{}
-	return singleFakeData(WORD, func() interface{} {
+	return singleFakeData(WORD, func() any {
 		return i.word()
 	}, opts...).(string)
 }
@@ -103,7 +103,7 @@ func (l Lorem) sentence(sentence *strings.Builder) *strings.Builder {
 }
 
 // Sentence returns a sentence using the wordList const
-func (l Lorem) Sentence(_ reflect.Value) (interface{}, error) {
+func (l Lorem) Sentence(_ reflect.Value) (any, error) {
 	sentence := l.sentence(&strings.Builder{})
 	return sentence.String(), nil
 }
@@ -111,7 +111,7 @@ func (l Lorem) Sentence(_ reflect.Value) (interface{}, error) {
 // Sentence get a sentence randomly in string
 func Sentence(opts ...options.OptionFunc) string {
 	i := Lorem{}
-	return singleFakeData(SENTENCE, func() interface{} {
+	return singleFakeData(SENTENCE, func() any {
 		return i.sentence(&strings.Builder{}).String()
 	}, opts...).(string)
 }
@@ -119,7 +119,7 @@ func Sentence(opts ...options.OptionFunc) string {
 func (l Lorem) paragraph() string {
 	paragraph := &strings.Builder{}
 	size := rand.Intn(10) + 1
-	for i := 0; i < size; i++ {
+	for i := range size {
 		l.sentence(paragraph)
 		if i != size-1 {
 			paragraph.WriteString(" ")
@@ -129,14 +129,14 @@ func (l Lorem) paragraph() string {
 }
 
 // Paragraph returns a series of sentences as a paragraph using the wordList const
-func (l Lorem) Paragraph(v reflect.Value) (interface{}, error) {
+func (l Lorem) Paragraph(v reflect.Value) (any, error) {
 	return l.paragraph(), nil
 }
 
 // Paragraph get a paragraph randomly in string
 func Paragraph(opts ...options.OptionFunc) string {
 	i := Lorem{}
-	return singleFakeData(PARAGRAPH, func() interface{} {
+	return singleFakeData(PARAGRAPH, func() any {
 		return i.paragraph()
 	}, opts...).(string)
 }

--- a/lorem_test.go
+++ b/lorem_test.go
@@ -88,7 +88,7 @@ func TestUniqueWordPanic(t *testing.T) {
 	}()
 
 	length := len(wordList) + 1
-	for i := 0; i < length; i++ {
+	for range length {
 		Word(options.WithGenerateUniqueValues(true))
 	}
 	ResetUnique()

--- a/misc/makefile/tools.Makefile
+++ b/misc/makefile/tools.Makefile
@@ -42,7 +42,7 @@ bin/tparse: bin
 GOLANGCI := $(shell command -v golangci-lint || echo "bin/golangci-lint")
 golangci-lint: bin/golangci-lint ## Installs golangci-lint (linter)
 
-bin/golangci-lint: VERSION := 2.1.6
+bin/golangci-lint: VERSION := 2.12.2
 bin/golangci-lint: GITHUB  := golangci/golangci-lint
 bin/golangci-lint: ARCHIVE := golangci-lint-$(VERSION)-$(OSTYPE)-amd64.tar.gz
 bin/golangci-lint: bin

--- a/payment.go
+++ b/payment.go
@@ -38,8 +38,8 @@ func GetPayment() Render {
 
 // Render contains Whole Random Credit Card Generators with their types
 type Render interface {
-	CreditCardType(v reflect.Value) (interface{}, error)
-	CreditCardNumber(v reflect.Value) (interface{}, error)
+	CreditCardType(v reflect.Value) (any, error)
+	CreditCardNumber(v reflect.Value) (any, error)
 }
 
 // Payment struct
@@ -61,13 +61,13 @@ func (p Payment) cctype() string {
 
 // CreditCardType returns one of the following credit values:
 // VISA, MasterCard, American Express, Discover, JCB and Diners Club
-func (p Payment) CreditCardType(v reflect.Value) (interface{}, error) {
+func (p Payment) CreditCardType(v reflect.Value) (any, error) {
 	return p.cctype(), nil
 }
 
 // CCType get a credit card type randomly in string (VISA, MasterCard, etc)
 func CCType(opts ...options.OptionFunc) string {
-	return singleFakeData(CreditCardType, func() interface{} {
+	return singleFakeData(CreditCardType, func() any {
 		p := Payment{}
 		return p.cctype()
 	}, opts...).(string)
@@ -87,13 +87,13 @@ func (p Payment) ccnumber() string {
 }
 
 // CreditCardNumber generated credit card number according to the card number rules
-func (p Payment) CreditCardNumber(v reflect.Value) (interface{}, error) {
+func (p Payment) CreditCardNumber(v reflect.Value) (any, error) {
 	return p.ccnumber(), nil
 }
 
 // CCNumber get a credit card number randomly in string (VISA, MasterCard, etc)
 func CCNumber(opts ...options.OptionFunc) string {
-	return singleFakeData(CreditCardNumber, func() interface{} {
+	return singleFakeData(CreditCardNumber, func() any {
 		p := Payment{}
 		return p.ccnumber()
 	}, opts...).(string)

--- a/person.go
+++ b/person.go
@@ -9,23 +9,23 @@ import (
 
 // Dowser provides interfaces to generate random logical Names with their initials
 type Dowser interface {
-	TitleMale(v reflect.Value) (interface{}, error)
-	TitleFeMale(v reflect.Value) (interface{}, error)
-	FirstName(v reflect.Value) (interface{}, error)
-	FirstNameMale(v reflect.Value) (interface{}, error)
-	FirstNameFemale(v reflect.Value) (interface{}, error)
-	LastName(v reflect.Value) (interface{}, error)
-	Name(v reflect.Value) (interface{}, error)
-	Gender(v reflect.Value) (interface{}, error)
-	ChineseFirstName(v reflect.Value) (interface{}, error)
-	ChineseLastName(v reflect.Value) (interface{}, error)
-	ChineseName(v reflect.Value) (interface{}, error)
-	RussianFirstNameMale(v reflect.Value) (interface{}, error)
-	RussianMiddleNameMale(v reflect.Value) (interface{}, error)
-	RussianLastNameMale(v reflect.Value) (interface{}, error)
-	RussianFirstNameFemale(v reflect.Value) (interface{}, error)
-	RussianMiddleNameFemale(v reflect.Value) (interface{}, error)
-	RussianLastNameFemale(v reflect.Value) (interface{}, error)
+	TitleMale(v reflect.Value) (any, error)
+	TitleFeMale(v reflect.Value) (any, error)
+	FirstName(v reflect.Value) (any, error)
+	FirstNameMale(v reflect.Value) (any, error)
+	FirstNameFemale(v reflect.Value) (any, error)
+	LastName(v reflect.Value) (any, error)
+	Name(v reflect.Value) (any, error)
+	Gender(v reflect.Value) (any, error)
+	ChineseFirstName(v reflect.Value) (any, error)
+	ChineseLastName(v reflect.Value) (any, error)
+	ChineseName(v reflect.Value) (any, error)
+	RussianFirstNameMale(v reflect.Value) (any, error)
+	RussianMiddleNameMale(v reflect.Value) (any, error)
+	RussianLastNameMale(v reflect.Value) (any, error)
+	RussianFirstNameFemale(v reflect.Value) (any, error)
+	RussianMiddleNameFemale(v reflect.Value) (any, error)
+	RussianLastNameFemale(v reflect.Value) (any, error)
 }
 
 var titlesMale = []string{
@@ -637,13 +637,13 @@ func (p Person) titlemale() string {
 }
 
 // TitleMale generates random titles for males
-func (p Person) TitleMale(v reflect.Value) (interface{}, error) {
+func (p Person) TitleMale(v reflect.Value) (any, error) {
 	return p.titlemale(), nil
 }
 
 // TitleMale get a title male randomly in string ("Mr.", "Dr.", "Prof.", "Lord", "King", "Prince")
 func TitleMale(opts ...options.OptionFunc) string {
-	return singleFakeData(TitleMaleTag, func() interface{} {
+	return singleFakeData(TitleMaleTag, func() any {
 		p := Person{}
 		return p.titlemale()
 	}, opts...).(string)
@@ -654,13 +654,13 @@ func (p Person) titleFemale() string {
 }
 
 // TitleFeMale generates random titles for females
-func (p Person) TitleFeMale(v reflect.Value) (interface{}, error) {
+func (p Person) TitleFeMale(v reflect.Value) (any, error) {
 	return p.titleFemale(), nil
 }
 
 // TitleFemale get a title female randomly in string ("Mrs.", "Ms.", "Miss", "Dr.", "Prof.", "Lady", "Queen", "Princess")
 func TitleFemale(opts ...options.OptionFunc) string {
-	return singleFakeData(TitleFemaleTag, func() interface{} {
+	return singleFakeData(TitleFemaleTag, func() any {
 		p := Person{}
 		return p.titleFemale()
 	}, opts...).(string)
@@ -671,13 +671,13 @@ func (p Person) firstname() string {
 }
 
 // FirstName returns first names
-func (p Person) FirstName(v reflect.Value) (interface{}, error) {
+func (p Person) FirstName(v reflect.Value) (any, error) {
 	return p.firstname(), nil
 }
 
 // FirstName get fake firstname
 func FirstName(opts ...options.OptionFunc) string {
-	return singleFakeData(FirstNameTag, func() interface{} {
+	return singleFakeData(FirstNameTag, func() any {
 		p := Person{}
 		return p.firstname()
 	}, opts...).(string)
@@ -688,13 +688,13 @@ func (p Person) firstnamemale() string {
 }
 
 // FirstNameMale returns first names for males
-func (p Person) FirstNameMale(v reflect.Value) (interface{}, error) {
+func (p Person) FirstNameMale(v reflect.Value) (any, error) {
 	return p.firstnamemale(), nil
 }
 
 // FirstNameMale get fake firstname for male
 func FirstNameMale(opts ...options.OptionFunc) string {
-	return singleFakeData(FirstNameMaleTag, func() interface{} {
+	return singleFakeData(FirstNameMaleTag, func() any {
 		p := Person{}
 		return p.firstnamemale()
 	}, opts...).(string)
@@ -705,13 +705,13 @@ func (p Person) firstnamefemale() string {
 }
 
 // FirstNameFemale returns first names for females
-func (p Person) FirstNameFemale(v reflect.Value) (interface{}, error) {
+func (p Person) FirstNameFemale(v reflect.Value) (any, error) {
 	return p.firstnamefemale(), nil
 }
 
 // FirstNameFemale get fake firstname for female
 func FirstNameFemale(opts ...options.OptionFunc) string {
-	return singleFakeData(FirstNameFemaleTag, func() interface{} {
+	return singleFakeData(FirstNameFemaleTag, func() any {
 		p := Person{}
 		return p.firstnamefemale()
 	}, opts...).(string)
@@ -722,13 +722,13 @@ func (p Person) lastname() string {
 }
 
 // LastName returns last name
-func (p Person) LastName(v reflect.Value) (interface{}, error) {
+func (p Person) LastName(v reflect.Value) (any, error) {
 	return p.lastname(), nil
 }
 
 // LastName get fake lastname
 func LastName(opts ...options.OptionFunc) string {
-	return singleFakeData(LastNameTag, func() interface{} {
+	return singleFakeData(LastNameTag, func() any {
 		p := Person{}
 		return p.lastname()
 	}, opts...).(string)
@@ -742,20 +742,20 @@ func (p Person) name() string {
 }
 
 // Name returns a random name
-func (p Person) Name(v reflect.Value) (interface{}, error) {
+func (p Person) Name(v reflect.Value) (any, error) {
 	return p.name(), nil
 }
 
 // Name get fake name
 func Name(opts ...options.OptionFunc) string {
-	return singleFakeData(NAME, func() interface{} {
+	return singleFakeData(NAME, func() any {
 		p := Person{}
 		return p.name()
 	}, opts...).(string)
 }
 
 // Gender returns a random gender
-func (p Person) Gender(v reflect.Value) (interface{}, error) {
+func (p Person) Gender(v reflect.Value) (any, error) {
 	return p.gender(), nil
 }
 
@@ -765,14 +765,14 @@ func (p Person) gender() string {
 
 // Gender get fake gender
 func Gender(opts ...options.OptionFunc) string {
-	return singleFakeData(GENDER, func() interface{} {
+	return singleFakeData(GENDER, func() any {
 		p := Person{}
 		return p.gender()
 	}, opts...).(string)
 }
 
 // ChineseFirstName returns a random chinese first name
-func (p Person) ChineseFirstName(v reflect.Value) (interface{}, error) {
+func (p Person) ChineseFirstName(v reflect.Value) (any, error) {
 	return p.chineseFirstName(), nil
 }
 
@@ -782,14 +782,14 @@ func (p Person) chineseFirstName() string {
 
 // ChineseFirstName get chinese first name
 func ChineseFirstName(opts ...options.OptionFunc) string {
-	return singleFakeData(ChineseFirstNameTag, func() interface{} {
+	return singleFakeData(ChineseFirstNameTag, func() any {
 		p := Person{}
 		return p.chineseFirstName()
 	}, opts...).(string)
 }
 
 // ChineseLastName returns a random chinese last name
-func (p Person) ChineseLastName(v reflect.Value) (interface{}, error) {
+func (p Person) ChineseLastName(v reflect.Value) (any, error) {
 	return p.chineseLastName(), nil
 }
 
@@ -799,14 +799,14 @@ func (p Person) chineseLastName() string {
 
 // ChineseLastName get chinese lsst name
 func ChineseLastName(opts ...options.OptionFunc) string {
-	return singleFakeData(ChineseLastNameTag, func() interface{} {
+	return singleFakeData(ChineseLastNameTag, func() any {
 		p := Person{}
 		return p.chineseLastName()
 	}, opts...).(string)
 }
 
 // ChineseName returns a random nhinese name
-func (p Person) ChineseName(v reflect.Value) (interface{}, error) {
+func (p Person) ChineseName(v reflect.Value) (any, error) {
 	return p.chineseName(), nil
 }
 
@@ -816,7 +816,7 @@ func (p Person) chineseName() string {
 
 // ChineseName get chinese lsst name
 func ChineseName(opts ...options.OptionFunc) string {
-	return singleFakeData(ChineseNameTag, func() interface{} {
+	return singleFakeData(ChineseNameTag, func() any {
 		p := Person{}
 		return p.chineseName()
 	}, opts...).(string)
@@ -847,31 +847,31 @@ func (p Person) russianLastNameFemale() string {
 }
 
 // RussianFirstNameMale returns russian male firstname
-func (p Person) RussianFirstNameMale(v reflect.Value) (interface{}, error) {
+func (p Person) RussianFirstNameMale(v reflect.Value) (any, error) {
 	return p.russianFirstNameMale(), nil
 }
 
 // RussianMiddleNameMale returns russian male middlename
-func (p Person) RussianMiddleNameMale(v reflect.Value) (interface{}, error) {
+func (p Person) RussianMiddleNameMale(v reflect.Value) (any, error) {
 	return p.russianMiddleNameMale(), nil
 }
 
 // RussianLastNameMale returns russian male lastname
-func (p Person) RussianLastNameMale(v reflect.Value) (interface{}, error) {
+func (p Person) RussianLastNameMale(v reflect.Value) (any, error) {
 	return p.russianLastNameMale(), nil
 }
 
 // RussianFirstNameFemale returns russian female firstname
-func (p Person) RussianFirstNameFemale(v reflect.Value) (interface{}, error) {
+func (p Person) RussianFirstNameFemale(v reflect.Value) (any, error) {
 	return p.russianFirstNameFemale(), nil
 }
 
 // RussianMiddleNameFemale returns russian female middlename
-func (p Person) RussianMiddleNameFemale(v reflect.Value) (interface{}, error) {
+func (p Person) RussianMiddleNameFemale(v reflect.Value) (any, error) {
 	return p.russianMiddleNameFemale(), nil
 }
 
 // RussianLastNameFemale returns russian female lastname
-func (p Person) RussianLastNameFemale(v reflect.Value) (interface{}, error) {
+func (p Person) RussianLastNameFemale(v reflect.Value) (any, error) {
 	return p.russianLastNameFemale(), nil
 }

--- a/phone.go
+++ b/phone.go
@@ -17,9 +17,9 @@ func GetPhoner() Phoner {
 
 // Phoner serves overall tele-phonic contact generator
 type Phoner interface {
-	PhoneNumber(v reflect.Value) (interface{}, error)
-	TollFreePhoneNumber(v reflect.Value) (interface{}, error)
-	E164PhoneNumber(v reflect.Value) (interface{}, error)
+	PhoneNumber(v reflect.Value) (any, error)
+	TollFreePhoneNumber(v reflect.Value) (any, error)
+	E164PhoneNumber(v reflect.Value) (any, error)
 }
 
 // Phone struct
@@ -33,40 +33,40 @@ func (p Phone) phonenumber() string {
 }
 
 // PhoneNumber generates phone numbers of type: "201-886-0269"
-func (p Phone) PhoneNumber(v reflect.Value) (interface{}, error) {
+func (p Phone) PhoneNumber(v reflect.Value) (any, error) {
 	return p.phonenumber(), nil
 }
 
 // Phonenumber get fake phone number
 func Phonenumber(opts ...options.OptionFunc) string {
-	return singleFakeData(PhoneNumber, func() interface{} {
+	return singleFakeData(PhoneNumber, func() any {
 		p := Phone{}
 		return p.phonenumber()
 	}, opts...).(string)
 }
 
 func (p Phone) tollfreephonenumber() string {
-	out := ""
+	var out strings.Builder
 	boxDigitsStart := []string{"777", "888"}
 
 	ints, _ := RandomInt(1, 9)
 	for index, v := range slice.IntToString(ints) {
 		if index == 3 {
-			out += "-"
+			out.WriteString("-")
 		}
-		out += v
+		out.WriteString(v)
 	}
-	return fmt.Sprintf("(%s) %s", boxDigitsStart[rand.Intn(len(boxDigitsStart))], out)
+	return fmt.Sprintf("(%s) %s", boxDigitsStart[rand.Intn(len(boxDigitsStart))], out.String())
 }
 
 // TollFreePhoneNumber generates phone numbers of type: "(888) 937-7238"
-func (p Phone) TollFreePhoneNumber(v reflect.Value) (interface{}, error) {
+func (p Phone) TollFreePhoneNumber(v reflect.Value) (any, error) {
 	return p.tollfreephonenumber(), nil
 }
 
 // TollFreePhoneNumber get fake TollFreePhoneNumber
 func TollFreePhoneNumber(opts ...options.OptionFunc) string {
-	return singleFakeData(TollFreeNumber, func() interface{} {
+	return singleFakeData(TollFreeNumber, func() any {
 		p := Phone{}
 		return p.tollfreephonenumber()
 	}, opts...).(string)
@@ -84,13 +84,13 @@ func (p Phone) e164PhoneNumber() string {
 }
 
 // E164PhoneNumber generates phone numbers of type: "+27113456789"
-func (p Phone) E164PhoneNumber(v reflect.Value) (interface{}, error) {
+func (p Phone) E164PhoneNumber(v reflect.Value) (any, error) {
 	return p.e164PhoneNumber(), nil
 }
 
 // E164PhoneNumber get fake E164PhoneNumber
 func E164PhoneNumber(opts ...options.OptionFunc) string {
-	return singleFakeData(E164PhoneNumberTag, func() interface{} {
+	return singleFakeData(E164PhoneNumberTag, func() any {
 		p := Phone{}
 		return p.e164PhoneNumber()
 	}, opts...).(string)

--- a/pkg/interfaces/type.go
+++ b/pkg/interfaces/type.go
@@ -3,8 +3,8 @@ package interfaces
 import "reflect"
 
 // CustomProviderFunction used as the standard layout function for custom providers
-type CustomProviderFunction func() (interface{}, error)
+type CustomProviderFunction func() (any, error)
 
 // TaggedFunction used as the standard layout function for tag providers in struct.
 // This type also can be used for custom provider.
-type TaggedFunction func(v reflect.Value) (interface{}, error)
+type TaggedFunction func(v reflect.Value) (any, error)

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -135,7 +135,7 @@ func BuildOptions(optFuncs []OptionFunc) *Options {
 func DefaultOption() *Options {
 	ops := &Options{}
 	ops.StructTypeProviders = make(map[reflect.Type]interfaces.CustomProviderFunction)
-	ops.StructTypeProviders[reflect.TypeOf(time.Time{})] = func() (interface{}, error) {
+	ops.StructTypeProviders[reflect.TypeFor[time.Time]()] = func() (any, error) {
 		return time.Now().Add(time.Duration(rand.Int63())), nil
 	}
 	ops.MaxDepthOption = &MaxDepthOption{
@@ -209,7 +209,7 @@ func WithMaxFieldDepthOption(depth int) OptionFunc {
 }
 
 // WithStructTypeProviders used for configuring the custom provider of struct type
-func WithStructTypeProviders(t interface{}, provider interfaces.CustomProviderFunction) OptionFunc {
+func WithStructTypeProviders(t any, provider interfaces.CustomProviderFunction) OptionFunc {
 	if reflect.TypeOf(t).Kind() != reflect.Struct {
 		panic(fakerErrors.ErrOnlyStructTypeSupported)
 	}

--- a/pkg/slice/helpers.go
+++ b/pkg/slice/helpers.go
@@ -23,10 +23,8 @@ func ContainsValue(slice []any, value any) bool {
 
 // IntToString Convert slice int to slice string
 func IntToString(intSl []int) (str []string) {
-	for i := range intSl {
-		number := intSl[i]
-		text := strconv.Itoa(number)
-		str = append(str, text)
+	for _, number := range intSl {
+		str = append(str, strconv.Itoa(number))
 	}
 	return str
 }

--- a/pkg/slice/helpers.go
+++ b/pkg/slice/helpers.go
@@ -1,17 +1,13 @@
 package slice
 
 import (
+	"slices"
 	"strconv"
 )
 
 // Contains Check item in slice string type
 func Contains(slice []string, item string) bool {
-	for _, s := range slice {
-		if s == item {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, item)
 }
 
 // ContainsRune Check item in map rune type
@@ -21,13 +17,8 @@ func ContainsRune(set map[rune]struct{}, item rune) bool {
 }
 
 // ContainsValue check if value exists in slice, no matter its type
-func ContainsValue(slice []interface{}, value interface{}) bool {
-	for _, v := range slice {
-		if v == value {
-			return true
-		}
-	}
-	return false
+func ContainsValue(slice []any, value any) bool {
+	return slices.Contains(slice, value)
 }
 
 // IntToString Convert slice int to slice string

--- a/price.go
+++ b/price.go
@@ -34,9 +34,9 @@ var currencies = []string{
 
 // Money provides an interface to generate a custom price with or without a random currency code
 type Money interface {
-	Currency(v reflect.Value) (interface{}, error)
-	Amount(v reflect.Value) (interface{}, error)
-	AmountWithCurrency(v reflect.Value) (interface{}, error)
+	Currency(v reflect.Value) (any, error)
+	Amount(v reflect.Value) (any, error)
+	AmountWithCurrency(v reflect.Value) (any, error)
 }
 
 // Price struct
@@ -53,13 +53,13 @@ func (p Price) currency() string {
 }
 
 // Currency returns a random currency from currencies
-func (p Price) Currency(v reflect.Value) (interface{}, error) {
+func (p Price) Currency(v reflect.Value) (any, error) {
 	return p.currency(), nil
 }
 
 // Currency get fake Currency (IDR, USD)
 func Currency(opts ...options.OptionFunc) string {
-	return singleFakeData(CurrencyTag, func() interface{} {
+	return singleFakeData(CurrencyTag, func() any {
 		p := Price{}
 		return p.currency()
 	}, opts...).(string)
@@ -71,7 +71,7 @@ func (p Price) amount() float64 {
 
 // Amount returns a random floating price amount
 // with a random precision of [1,2] up to (10**8 - 1)
-func (p Price) Amount(v reflect.Value) (interface{}, error) {
+func (p Price) Amount(v reflect.Value) (any, error) {
 	kind := v.Kind()
 	val := p.amount()
 	if kind == reflect.Float32 {
@@ -88,13 +88,13 @@ func (p Price) amountwithcurrency() string {
 }
 
 // AmountWithCurrency combines both price and currency together
-func (p Price) AmountWithCurrency(v reflect.Value) (interface{}, error) {
+func (p Price) AmountWithCurrency(v reflect.Value) (any, error) {
 	return p.amountwithcurrency(), nil
 }
 
 // AmountWithCurrency get fake AmountWithCurrency  USD 49257.100
 func AmountWithCurrency(opts ...options.OptionFunc) string {
-	return singleFakeData(AmountWithCurrencyTag, func() interface{} {
+	return singleFakeData(AmountWithCurrencyTag, func() any {
 		p := Price{}
 		return p.amountwithcurrency()
 	}, opts...).(string)

--- a/tag_argument_extractor.go
+++ b/tag_argument_extractor.go
@@ -8,7 +8,7 @@ import (
 	fakerErrors "github.com/go-faker/faker/v4/pkg/errors"
 )
 
-func extractFloat64FromTagArgs(args []string) (interface{}, error) {
+func extractFloat64FromTagArgs(args []string) (any, error) {
 	bytes := 64
 	var floatValues []float64
 	for _, i := range args {
@@ -23,7 +23,7 @@ func extractFloat64FromTagArgs(args []string) (interface{}, error) {
 	return toRet, nil
 }
 
-func extractFloat32FromTagArgs(args []string) (interface{}, error) {
+func extractFloat32FromTagArgs(args []string) (any, error) {
 	bytes := 32
 	var floatValues []float32
 	for _, i := range args {
@@ -38,7 +38,7 @@ func extractFloat32FromTagArgs(args []string) (interface{}, error) {
 	return toRet, nil
 }
 
-func extractInt64FromTagArgs(args []string) (interface{}, error) {
+func extractInt64FromTagArgs(args []string) (any, error) {
 	bytes := 64
 	var floatValues []int64
 	for _, i := range args {
@@ -53,7 +53,7 @@ func extractInt64FromTagArgs(args []string) (interface{}, error) {
 	return toRet, nil
 }
 
-func extractInt32FromTagArgs(args []string) (interface{}, error) {
+func extractInt32FromTagArgs(args []string) (any, error) {
 	bytes := 32
 	var floatValues []int32
 	for _, i := range args {
@@ -68,7 +68,7 @@ func extractInt32FromTagArgs(args []string) (interface{}, error) {
 	return toRet, nil
 }
 
-func extractInt16FromTagArgs(args []string) (interface{}, error) {
+func extractInt16FromTagArgs(args []string) (any, error) {
 	bytes := 16
 	var floatValues []int16
 	for _, i := range args {
@@ -83,7 +83,7 @@ func extractInt16FromTagArgs(args []string) (interface{}, error) {
 	return toRet, nil
 }
 
-func extractInt8FromTagArgs(args []string) (interface{}, error) {
+func extractInt8FromTagArgs(args []string) (any, error) {
 	bytes := 8
 	var floatValues []int8
 	for _, i := range args {
@@ -98,7 +98,7 @@ func extractInt8FromTagArgs(args []string) (interface{}, error) {
 	return toRet, nil
 }
 
-func extractIntFromTagArgs(args []string) (interface{}, error) {
+func extractIntFromTagArgs(args []string) (any, error) {
 	bytes := 0
 	var floatValues []int
 	for _, i := range args {
@@ -113,7 +113,7 @@ func extractIntFromTagArgs(args []string) (interface{}, error) {
 	return toRet, nil
 }
 
-func extractUint64FromTagArgs(args []string) (interface{}, error) {
+func extractUint64FromTagArgs(args []string) (any, error) {
 	bytes := 64
 	var floatValues []uint64
 	for _, i := range args {
@@ -128,7 +128,7 @@ func extractUint64FromTagArgs(args []string) (interface{}, error) {
 	return toRet, nil
 }
 
-func extractUint32FromTagArgs(args []string) (interface{}, error) {
+func extractUint32FromTagArgs(args []string) (any, error) {
 	bytes := 32
 	var floatValues []uint32
 	for _, i := range args {
@@ -143,7 +143,7 @@ func extractUint32FromTagArgs(args []string) (interface{}, error) {
 	return toRet, nil
 }
 
-func extractUint16FromTagArgs(args []string) (interface{}, error) {
+func extractUint16FromTagArgs(args []string) (any, error) {
 	bytes := 16
 	var floatValues []uint16
 	for _, i := range args {
@@ -158,7 +158,7 @@ func extractUint16FromTagArgs(args []string) (interface{}, error) {
 	return toRet, nil
 }
 
-func extractUint8FromTagArgs(args []string) (interface{}, error) {
+func extractUint8FromTagArgs(args []string) (any, error) {
 	bytes := 8
 	var floatValues []uint8
 	for _, i := range args {
@@ -173,7 +173,7 @@ func extractUint8FromTagArgs(args []string) (interface{}, error) {
 	return toRet, nil
 }
 
-func extractUintFromTagArgs(args []string) (interface{}, error) {
+func extractUintFromTagArgs(args []string) (any, error) {
 	bytes := 0
 	var floatValues []uint
 	for _, i := range args {

--- a/user_agent.go
+++ b/user_agent.go
@@ -38,13 +38,13 @@ func GetUserAgent() UserAgenter {
 }
 
 type UserAgenter interface {
-	UserAgent(v reflect.Value) (interface{}, error)
+	UserAgent(v reflect.Value) (any, error)
 }
 
 // UserAgent implements logic loosely based on https://fakerphp.org/formatters/user-agent/.
 type UserAgent struct{}
 
-func (ua UserAgent) UserAgent(reflect.Value) (interface{}, error) {
+func (ua UserAgent) UserAgent(reflect.Value) (any, error) {
 	browserType := randomElementFromSliceString(browserTypes)
 	switch browserType {
 	case "chrome":

--- a/uuid.go
+++ b/uuid.go
@@ -15,8 +15,8 @@ func GetIdentifier() Identifier {
 
 // Identifier ...
 type Identifier interface {
-	Digit(v reflect.Value) (interface{}, error)
-	Hyphenated(v reflect.Value) (interface{}, error)
+	Digit(v reflect.Value) (any, error)
+	Hyphenated(v reflect.Value) (any, error)
 }
 
 // UUID struct
@@ -46,13 +46,13 @@ func (u UUID) hyphenated() (string, error) {
 }
 
 // Hyphenated returns a 36 byte hyphenated UUID
-func (u UUID) Hyphenated(v reflect.Value) (interface{}, error) {
+func (u UUID) Hyphenated(v reflect.Value) (any, error) {
 	return u.hyphenated()
 }
 
 // UUIDHyphenated get fake Hyphenated UUID
 func UUIDHyphenated(opts ...options.OptionFunc) string {
-	return singleFakeData(HyphenatedID, func() interface{} {
+	return singleFakeData(HyphenatedID, func() any {
 		u := UUID{}
 		res, _ := u.hyphenated()
 		return res
@@ -69,13 +69,13 @@ func (u UUID) digit() (string, error) {
 }
 
 // Digit returns a 32 bytes UUID
-func (u UUID) Digit(v reflect.Value) (interface{}, error) {
+func (u UUID) Digit(v reflect.Value) (any, error) {
 	return u.digit()
 }
 
 // UUIDDigit get fake Digit UUID
 func UUIDDigit(opts ...options.OptionFunc) string {
-	return singleFakeData(ID, func() interface{} {
+	return singleFakeData(ID, func() any {
 		u := UUID{}
 		res, _ := u.digit()
 		return res


### PR DESCRIPTION
Upgrades the module to Go 1.26 and runs the modernization fixers that ship with it, plus the tooling and CI changes needed to keep the matrix honest.

## Go version

`go.mod` moves from `1.24.0` to `1.26.0`, and the now-redundant `toolchain` line is gone. The directive stays at minor level (`1.26.0`, not a specific patch) on purpose: patch releases add no language features, so pinning `1.26.5` would force every consumer and CI runner onto that exact build for nothing. Any `1.26.x` satisfies the floor.

## Modernization (`go fix`)

Mechanical rewrites applied across the codebase, behavior unchanged:

- `interface{}` becomes `any`
- `reflect.Ptr` becomes `reflect.Pointer`
- Counter loops that only use the index become `for i := range n`
- Hand-rolled "does this slice contain X" loops become `slices.Contains`

## Tooling and lint

- Bumped golangci-lint `2.1.6` to `2.12.2` in `tools.Makefile`. The old build can't load a Go 1.26 module, so lint failed before it ran a single check.
- Added a `goconst` exclusion for `lorem.go` in `.golangci.yaml`. The strings it flags ("et", "qui", "aut"...) are Latin words in the lorem-ipsum word list, not magic constants worth extracting.

## CI

Two changes to `.github/workflows/go.yml`, both about making the version matrix mean what it says:

- `GOTOOLCHAIN: local` at the workflow level. Without it, Go's default `auto` mode silently downloads whatever version `go.mod` requires and ignores the version `setup-go` installed, so every matrix leg secretly runs the same toolchain. `local` makes each leg run exactly what it installed, and fail loudly if that's below the floor instead of hiding the mismatch.
- Matrix aligned to `~1.26`. Every entry has to be at or above the `go.mod` floor now, otherwise it stops at the toolchain gate before compiling.

## Verification

- `go build ./...`: clean
- `go vet ./...`: clean
- `go test ./...`: 274 tests pass across 5 packages
