### PR TITLE
feat: add chinese_phone_number tag for Mainland-China mobile numbers

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -63,6 +63,7 @@ const (
 	ChineseFirstNameTag        = "chinese_first_name"
 	ChineseLastNameTag         = "chinese_last_name"
 	ChineseNameTag             = "chinese_name"
+	ChinesePhoneNumberTag      = "chinese_phone_number"
 	GENDER                     = "gender"
 	UnixTimeTag                = "unix_time"
 	DATE                       = "date"
@@ -107,7 +108,7 @@ const (
 var PriorityTags = []string{ID, HyphenatedID, EmailTag, MacAddressTag, DomainNameTag, UserNameTag, URLTag, IPV4Tag,
 	IPV6Tag, PASSWORD, JWT, CountryInfoTag, LATITUDE, LONGITUDE, CreditCardNumber, CreditCardType, PhoneNumber, TollFreeNumber,
 	E164PhoneNumberTag, TitleMaleTag, TitleFemaleTag, FirstNameTag, FirstNameMaleTag, FirstNameFemaleTag, LastNameTag,
-	NAME, ChineseFirstNameTag, ChineseLastNameTag, ChineseNameTag, GENDER, UnixTimeTag, DATE, TIME, MonthNameTag,
+	NAME, ChineseFirstNameTag, ChineseLastNameTag, ChineseNameTag, ChinesePhoneNumberTag, GENDER, UnixTimeTag, DATE, TIME, MonthNameTag,
 	YEAR, DayOfWeekTag, DayOfMonthTag, TIMESTAMP, CENTURY, TIMEZONE, TimePeriodTag, WORD, SENTENCE, PARAGRAPH,
 	CurrencyTag, AmountTag, AmountWithCurrencyTag, SKIP, Length, SliceLength, Language, BoundaryStart, BoundaryEnd, ONEOF, BloodTypeTag,
 	UserAgentTag,
@@ -169,6 +170,7 @@ func initDefaultTag() {
 	defaultTag.Store(ChineseFirstNameTag, ChineseFirstNameTag)
 	defaultTag.Store(ChineseLastNameTag, ChineseLastNameTag)
 	defaultTag.Store(ChineseNameTag, ChineseNameTag)
+	defaultTag.Store(ChinesePhoneNumberTag, ChinesePhoneNumberTag)
 	defaultTag.Store(GENDER, GENDER)
 	defaultTag.Store(UnixTimeTag, UnixTimeTag)
 	defaultTag.Store(DATE, DATE)
@@ -220,6 +222,7 @@ func initMapperTagDefault() {
 	mapperTag.Store(ChineseFirstNameTag, GetPerson().ChineseFirstName)
 	mapperTag.Store(ChineseLastNameTag, GetPerson().ChineseLastName)
 	mapperTag.Store(ChineseNameTag, GetPerson().ChineseName)
+	mapperTag.Store(ChinesePhoneNumberTag, GetPhoner().ChinesePhoneNumber)
 	mapperTag.Store(GENDER, GetPerson().Gender)
 	mapperTag.Store(UnixTimeTag, GetDateTimer().UnixTime)
 	mapperTag.Store(DATE, GetDateTimer().Date)

--- a/faker_test.go
+++ b/faker_test.go
@@ -283,6 +283,7 @@ type TaggedStruct struct {
 	ChineseFirstName   string  `faker:"chinese_first_name"   custom_tag_name:"chinese_first_name"`
 	ChineseLastName    string  `faker:"chinese_last_name"    custom_tag_name:"chinese_last_name"`
 	ChineseName        string  `faker:"chinese_name"         custom_tag_name:"chinese_name"`
+	ChinesePhoneNumber string  `faker:"chinese_phone_number" custom_tag_name:"chinese_phone_number"`
 	UnixTime           int64   `faker:"unix_time"            custom_tag_name:"unix_time"`
 	Date               string  `faker:"date"                 custom_tag_name:"date"`
 	Time               string  `faker:"time"                 custom_tag_name:"time"`

--- a/phone.go
+++ b/phone.go
@@ -9,6 +9,20 @@ import (
 	"github.com/go-faker/faker/v4/pkg/slice"
 )
 
+// chineseMobilePrefixes holds the 3-digit prefixes of Mainland China mobile
+// numbers, allocated to China Mobile, China Unicom, China Telecom and China
+// Broadnet (including MVNO & IoT segments). Each prefix is followed by 8
+// subscriber digits to form an 11-digit number.
+var chineseMobilePrefixes = []string{
+	"130", "131", "132", "133", "134", "135", "136", "137", "138", "139",
+	"145", "146", "147", "148", "149",
+	"150", "151", "152", "153", "155", "156", "157", "158", "159",
+	"162", "165", "166", "167",
+	"170", "171", "172", "173", "174", "175", "176", "177", "178",
+	"180", "181", "182", "183", "184", "185", "186", "187", "188", "189",
+	"190", "191", "192", "193", "195", "196", "197", "198", "199",
+}
+
 // GetPhoner serves as a constructor for Phoner interface
 func GetPhoner() Phoner {
 	phone := &Phone{}
@@ -20,6 +34,7 @@ type Phoner interface {
 	PhoneNumber(v reflect.Value) (any, error)
 	TollFreePhoneNumber(v reflect.Value) (any, error)
 	E164PhoneNumber(v reflect.Value) (any, error)
+	ChinesePhoneNumber(v reflect.Value) (any, error)
 }
 
 // Phone struct
@@ -93,5 +108,24 @@ func E164PhoneNumber(opts ...options.OptionFunc) string {
 	return singleFakeData(E164PhoneNumberTag, func() any {
 		p := Phone{}
 		return p.e164PhoneNumber()
+	}, opts...).(string)
+}
+
+func (p Phone) chinesePhoneNumber() string {
+	prefix := chineseMobilePrefixes[rand.Intn(len(chineseMobilePrefixes))]
+	return prefix + randomStringNumber(8)
+}
+
+// ChinesePhoneNumber generates a Mainland-China mobile phone number of the
+// form "13812345678" (11 digits, starting with a valid operator prefix)
+func (p Phone) ChinesePhoneNumber(v reflect.Value) (any, error) {
+	return p.chinesePhoneNumber(), nil
+}
+
+// ChinesePhoneNumber get fake Chinese phone number
+func ChinesePhoneNumber(opts ...options.OptionFunc) string {
+	return singleFakeData(ChinesePhoneNumberTag, func() any {
+		p := Phone{}
+		return p.chinesePhoneNumber()
 	}, opts...).(string)
 }

--- a/phone_test.go
+++ b/phone_test.go
@@ -56,3 +56,52 @@ func TestFakeE164PhoneNumber(t *testing.T) {
 		t.Error("Expected character '(888)', in function TollFreePhoneNumber")
 	}
 }
+
+func isValidChineseMobileNumber(number string) bool {
+	if len(number) != 11 || number[0] != '1' {
+		return false
+	}
+	for _, r := range number {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	prefix := number[:3]
+	for _, p := range chineseMobilePrefixes {
+		if p == prefix {
+			return true
+		}
+	}
+	return false
+}
+
+func TestChinesePhoneNumber(t *testing.T) {
+	ph, err := GetPhoner().ChinesePhoneNumber(reflect.Value{})
+	if err != nil {
+		t.Error("Expected  not error, got err", err)
+	}
+	if !isValidChineseMobileNumber(ph.(string)) {
+		t.Errorf("Expected a valid Chinese mobile number, got: %s", ph.(string))
+	}
+}
+
+func TestFakeChinesePhoneNumber(t *testing.T) {
+	ph := ChinesePhoneNumber()
+	if !isValidChineseMobileNumber(ph) {
+		t.Errorf("Expected a valid Chinese mobile number, got: %s", ph)
+	}
+}
+
+type chinesePhoneStruct struct {
+	Number string `faker:"chinese_phone_number"`
+}
+
+func TestChinesePhoneNumberTag(t *testing.T) {
+	s := chinesePhoneStruct{}
+	if err := FakeData(&s); err != nil {
+		t.Fatal("Expected NoError, but got Err:", err)
+	}
+	if !isValidChineseMobileNumber(s.Number) {
+		t.Errorf("Expected a valid Chinese mobile number, got: %s", s.Number)
+	}
+}


### PR DESCRIPTION
## What
Adds a new `chinese_phone_number` tag that generates Mainland-China mobile
numbers (11 digits, e.g. `13812345678`).

## Why
The current `phone_number` / `e_164_phone_number` tags only produce Western
style numbers. Chinese data sets currently only cover names.

## How
- Pick a real 3-digit operator prefix from a curated list of 56 allocated
  prefixes (China Mobile / Unicom / Telecom / Broadnet, incl. MVNO & IoT
  segments), then append 8 random digits.
- Follows the existing pattern of the `chinese_first_name`-style tags:
  tag constant + `PriorityTags` + `defaultTag` + `mapperTag` registration,
  `Phoner` interface method, standalone `ChinesePhoneNumber()` helper and
  unit tests (interface method, standalone call, and struct-tag end-to-end).

## Tests
`go test -race ./...` passes; new tests validate against `^1[3-9]\d{9}$`
and prefix membership.